### PR TITLE
integration of soda CLI

### DIFF
--- a/docs/documentation/cli.md
+++ b/docs/documentation/cli.md
@@ -45,7 +45,7 @@ To learn about the parameters, use the command line help:
 # Env vars
 
 To keep your `warehouse.yml` configuration files free of credentials, soda-sql
-supports to reference to environment variables by using the `env_vars(SOME_ENV_VAR)` format.
+supports to reference to environment variables by using the `env_var(SOME_ENV_VAR)` format.
 
 The `soda` CLI uses a convenient mechanism to load environment variables from your local
 user home directory.  Each `soda` CLI command which reads a warehouse configuration will

--- a/sodasql/cli/cli.py
+++ b/sodasql/cli/cli.py
@@ -8,12 +8,14 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+import datetime
 import logging
 import sys
 from typing import Optional
 
 import click
 import yaml
+
 from sodasql.cli.scan_initializer import ScanInitializer
 from sodasql.common.logging_helper import LoggingHelper
 from sodasql.scan.file_system import FileSystemSingleton
@@ -195,7 +197,7 @@ def init(warehouse_file: str):
               help='Variables like -v start=2020-04-12.  Put values with spaces in single or double quotes.')
 @click.option('-t', '--time',
               required=False,
-              default=None,
+              default=datetime.datetime.now().isoformat(timespec='seconds'),
               help='The scan time in ISO8601 format like eg 2020-12-31T16:48:30Z')
 def scan(scan_yml_file: str, warehouse_yml_file: str, variables: tuple = None, time: str = None):
     """
@@ -223,6 +225,7 @@ def scan(scan_yml_file: str, warehouse_yml_file: str, variables: tuple = None, t
         scan_builder = ScanBuilder()
         scan_builder.warehouse_yml_file = warehouse_yml_file
         scan_builder.scan_yml_file = scan_yml_file
+        scan_builder.time = time
 
         logging.info(f'Scanning {scan_yml_file} ...')
 

--- a/sodasql/scan/scan_builder.py
+++ b/sodasql/scan/scan_builder.py
@@ -60,6 +60,7 @@ class ScanBuilder:
         self.warehouse_yml_dict: dict = None
         self.warehouse_yml: WarehouseYml = None
         self.scan_yml_file: str = None
+        self.time: str = None
         self.scan_yml_dict: dict = None
         self.scan_yml: ScanYml = None
         self.variables: dict = {}
@@ -84,7 +85,8 @@ class ScanBuilder:
         return Scan(warehouse=warehouse,
                     scan_yml=self.scan_yml,
                     variables=self.variables,
-                    soda_server_client=self.soda_server_client)
+                    soda_server_client=self.soda_server_client,
+                    time=self.time)
 
     def _build_warehouse_yml(self):
         if not self.warehouse_yml_file and not self.warehouse_yml_dict and not self.warehouse_yml:
@@ -134,12 +136,20 @@ class ScanBuilder:
                 host = self.warehouse_yml.soda_host
                 api_key_id = self.warehouse_yml.soda_api_key_id
                 api_key_secret = self.warehouse_yml.soda_api_key_secret
+                port = str(self.warehouse_yml.soda_port)
+                protocol = self.warehouse_yml.soda_protocol
             else:
                 host = os.getenv('SODA_HOST', 'cloud.soda.io')
                 api_key_id = os.getenv('SODA_SERVER_API_KEY_ID', None)
                 api_key_secret = os.getenv('SODA_SERVER_API_KEY_SECRET', None)
+                port = os.getenv('SODA_PORT', '443')
+                protocol = os.getenv('SODA_PROTOCOL', 'https')
 
             if api_key_id and api_key_secret:
-                self.soda_server_client = SodaServerClient(host, api_key_id=api_key_id, api_key_secret=api_key_secret)
+                self.soda_server_client = SodaServerClient(host,
+                                                           api_key_id=api_key_id,
+                                                           api_key_secret=api_key_secret,
+                                                           protocol=protocol,
+                                                           port=port)
             else:
                 logging.debug("No Soda Cloud account configured")

--- a/sodasql/scan/warehouse_yml.py
+++ b/sodasql/scan/warehouse_yml.py
@@ -21,5 +21,7 @@ class WarehouseYml:
     dialect: Dialect = None
     name: str = None
     soda_host: Optional[str] = None
+    soda_port: Optional[int] = None
+    soda_protocol: Optional[str] = None
     soda_api_key_id: Optional[str] = None
     soda_api_key_secret: Optional[str] = None

--- a/sodasql/scan/warehouse_yml_parser.py
+++ b/sodasql/scan/warehouse_yml_parser.py
@@ -22,6 +22,8 @@ KEY_CONNECTION = 'connection'
 KEY_SODA_ACCOUNT = 'soda_account'
 
 SODA_KEY_HOST = 'host'
+SODA_KEY_PORT = 'port'
+SODA_KEY_PROTOCOL = 'protocol'
 SODA_KEY_API_KEY_ID = 'api_key_id'
 SODA_KEY_API_KEY_SECRET = 'api_key_secret'
 
@@ -66,6 +68,8 @@ class WarehouseYmlParser(Parser):
             if soda_account_dict:
                 self._push_context(object=soda_account_dict, name=KEY_SODA_ACCOUNT)
                 self.warehouse_yml.soda_host = self.get_str_optional(SODA_KEY_HOST, 'cloud.soda.io')
+                self.warehouse_yml.soda_port = self.get_int_optional(SODA_KEY_PORT, 443)
+                self.warehouse_yml.soda_protocol = self.get_str_optional(SODA_KEY_PROTOCOL, 'https')
                 self.warehouse_yml.soda_api_key_id = self.get_str_required(SODA_KEY_API_KEY_ID)
                 self.warehouse_yml.soda_api_key_secret = self.get_str_required(SODA_KEY_API_KEY_SECRET)
                 self._pop_context()


### PR DESCRIPTION
This pull request allows Soda CLI to be tested as a container image. To do that we need to choose any possible http port and host, and turn off https on demand for the soda client.

Additionally, the time seems not to be included into the cloud API which was exposed during tryouts.