### PR TITLE
Make it possible to secure the API credentials for cloud soda

### DIFF
--- a/sodasql/scan/warehouse_yml_parser.py
+++ b/sodasql/scan/warehouse_yml_parser.py
@@ -70,8 +70,8 @@ class WarehouseYmlParser(Parser):
                 self.warehouse_yml.soda_host = self.get_str_optional(SODA_KEY_HOST, 'cloud.soda.io')
                 self.warehouse_yml.soda_port = self.get_int_optional(SODA_KEY_PORT, 443)
                 self.warehouse_yml.soda_protocol = self.get_str_optional(SODA_KEY_PROTOCOL, 'https')
-                self.warehouse_yml.soda_api_key_id = self.get_str_required(SODA_KEY_API_KEY_ID)
-                self.warehouse_yml.soda_api_key_secret = self.get_str_required(SODA_KEY_API_KEY_SECRET)
+                self.warehouse_yml.soda_api_key_id = self.get_str_required_env(SODA_KEY_API_KEY_ID)
+                self.warehouse_yml.soda_api_key_secret = self.get_str_required_env(SODA_KEY_API_KEY_SECRET)
                 self._pop_context()
 
             self.check_invalid_keys(VALID_WAREHOUSE_KEYS)


### PR DESCRIPTION
This allows us to utilize `env_var()` syntax for API credentials:

```yaml
soda_account:
  host: env_var(SODA_HOST)
  api_key_id: env_var(API_KEY_ID)
  api_key_secret: env_var(API_KEY_SECRET)
```