### PR TITLE
* athena_dialect.py: remove member variable 'schema' as ... 

### DIFF
--- a/sodasql/dialects/athena_dialect.py
+++ b/sodasql/dialects/athena_dialect.py
@@ -25,7 +25,6 @@ class AthenaDialect(Dialect):
             self.aws_credentials = parser.get_aws_credentials_optional()
             self.athena_staging_dir = parser.get_str_required_env('staging_dir')
             self.database = parser.get_str_required_env('database')
-            self.schema = parser.get_str_required_env('schema')
 
     def default_connection_properties(self, params: dict):
         return {


### PR DESCRIPTION
a) it's not used and b) that means it's considered missing by the parser.
This solves issue #110 .