### PR TITLE
Implement validation of datasources and datasets using new API

### DIFF
--- a/scripts/recreate_venv.sh
+++ b/scripts/recreate_venv.sh
@@ -7,7 +7,7 @@ set -e
 VENV_DIR=.venv
 
 rm -rf $VENV_DIR
-rm -rf sodalite.egg-info
+rm -rf soda_sql.egg-info
 
 python3 -m venv $VENV_DIR
 source $VENV_DIR/bin/activate

--- a/sodasql/dialects/bigquery_dialect.py
+++ b/sodasql/dialects/bigquery_dialect.py
@@ -92,7 +92,7 @@ class BigQueryDialect(Dialect):
         try:
             return json.loads(parser.get_credential(credential_name))
         except JSONDecodeError as e:
-            parser.error(f'Error parsing credential %s: %s', credential_name, e)
+            parser.error(f'Error parsing credential {credential_name}: {e}', credential_name)
 
     def sql_expr_cast_text_to_number(self, quoted_column_name, validity_format):
         if validity_format == 'number_whole':

--- a/sodasql/dialects/postgres_dialect.py
+++ b/sodasql/dialects/postgres_dialect.py
@@ -8,7 +8,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from datetime import date
 
 import psycopg2
 

--- a/sodasql/scan/dialect.py
+++ b/sodasql/scan/dialect.py
@@ -76,7 +76,7 @@ class Dialect:
     def sql_connection_test(self):
         pass
 
-    def create_connection(self):
+    def create_connection(self, *args, **kwargs):
         raise RuntimeError('TODO override and implement this abstract method')
 
     def create_scan(self, *args, **kwargs):
@@ -346,3 +346,9 @@ class Dialect:
 
     def get_type_name(self, column_description):
         return str(column_description[1])
+
+    def is_connection_error(self, exception):
+        return False
+
+    def is_authentication_error(self, exception):
+        return False

--- a/sodasql/scan/warehouse.py
+++ b/sodasql/scan/warehouse.py
@@ -18,10 +18,10 @@ from sodasql.scan.warehouse_yml import WarehouseYml
 
 class Warehouse:
 
-    def __init__(self, warehouse_yml: WarehouseYml):
+    def __init__(self, warehouse_yml: WarehouseYml, *args, **kwargs):
         self.name = warehouse_yml.name
         self.dialect: Dialect = warehouse_yml.dialect
-        self.connection = self.dialect.create_connection()
+        self.connection = self.dialect.create_connection(*args, **kwargs)
 
     def sql_fetchone(self, sql) -> tuple:
         return sql_fetchone(self.connection, sql)

--- a/sodasql/soda_server_client/soda_server_client.py
+++ b/sodasql/soda_server_client/soda_server_client.py
@@ -46,7 +46,12 @@ class SodaServerClient:
                 scan_yml_column: ScanYmlColumn = scan_yml.columns[column_name]
                 soda_column_cfg = {}
                 if scan_yml_column.missing:
-                    soda_column_cfg['missingValues'] = scan_yml_column.missing
+                    if scan_yml_column.missing.values:
+                        soda_column_cfg['missingValues'] = scan_yml_column.missing.values
+                    if scan_yml_column.missing.values:
+                        soda_column_cfg['missingRegex'] = scan_yml_column.missing.regex
+                    if scan_yml_column.missing.values:
+                        soda_column_cfg['missingFormat'] = scan_yml_column.missing.format
                 validity = scan_yml_column.validity
                 if validity:
                     soda_column_cfg['validity'] = {

--- a/tests/common/mock_soda_server_client.py
+++ b/tests/common/mock_soda_server_client.py
@@ -11,7 +11,9 @@ class MockSodaServerClient(SodaServerClient):
         self.commands = []
 
     def execute_command(self, command: dict):
+        # Serializing is important as it ensures no exceptions occur during serialization
         json.dumps(command, indent=2)
+        # Still we use the unserialized version to check the results as that is easier
         self.commands.append(command)
         if command['type'] == 'sodaSqlScanStart':
             return {'scanReference': 'scanref-123'}

--- a/tests/local/warehouse/cloud/test_soda_server_client.py
+++ b/tests/local/warehouse/cloud/test_soda_server_client.py
@@ -13,7 +13,7 @@ import logging
 
 from sodasql.scan.metric import Metric
 from sodasql.scan.scan_yml_parser import KEY_METRICS, KEY_METRIC_GROUPS, KEY_COLUMNS, COLUMN_KEY_TESTS, KEY_SQL_METRICS, \
-    SQL_METRIC_KEY_TESTS, SQL_METRIC_KEY_SQL
+    SQL_METRIC_KEY_TESTS, SQL_METRIC_KEY_SQL, COLUMN_KEY_MISSING_VALUES
 from tests.common.sql_test_case import SqlTestCase
 
 
@@ -46,6 +46,7 @@ class TestSodaServerClient(SqlTestCase):
             }],
             KEY_COLUMNS: {
                 'name': {
+                    COLUMN_KEY_MISSING_VALUES: ['N/A'],
                     COLUMN_KEY_TESTS: [
                         f'{Metric.MISSING_COUNT} < 1',
                     ]

--- a/tests/postgres_container/docker-compose.yml
+++ b/tests/postgres_container/docker-compose.yml
@@ -1,6 +1,6 @@
 version: "3.7"
 services:
-  sodalite-postgres:
+  soda-sql-postgres:
     image: postgres:9.6.17-alpine
     ports:
       - "5432:5432"


### PR DESCRIPTION
For the managed scan validation to succeed, we need to track a bit in more details errors in YAML validation.

This means that we should be able to:

1. connect field validation errors with the field on which validation error occurred to make more helpful validation errors;
2. be able to detect errors when connection fails;
3. when authentication fails

The points 2) and 3) are quite helpful for frontend flow where customer plans on introducing their own warehouse and we want to verify that indeed we can reach out to it before a scan is scheduled.

I am currently only processing validation and authentication for PostgreSQL. I plan on trying the same approach for remaining warehouses, but you can already express your opinion on the approach here