### PR TITLE
Fixes #131. Quote the column names in postgres/redshift dialect

### DIFF
--- a/sodasql/dialects/postgres_dialect.py
+++ b/sodasql/dialects/postgres_dialect.py
@@ -74,6 +74,9 @@ class PostgresDialect(Dialect):
             return f'"{self.schema}"."{table_name}"'
         return f'"{table_name}"'
 
+    def qualify_column_name(self, column_name: str):
+        return f'"{column_name}"'
+
     def sql_expr_regexp_like(self, expr: str, pattern: str):
         return f"{expr} ~* '{self.qualify_regex(pattern)}'"
 


### PR DESCRIPTION
During my tests, I've found that redshift dialect brakes when the column name contains spaces. 