### PR TITLE
Pyodbc add new requirements

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -21,8 +21,8 @@ The soda-sql CLI requires the following dependencies to be installed on your sys
 - Pip >=21.0
 - postgresql-libs (`libpq-dev` in Debian/Ubuntu, `libpq-devel` in CentOS, `postgresql` on MacOSX)
 - _Linux only:_ 
-  + On Debian Buster: `g++`, `unixodbc-dev`, `python3-dev`, `libssl-dev` and `libffi-dev`
-  + On CentOS 8: `gcc-c++`, `unixODBC-devel`, `python38-devel`, `libffi-devel` and `openssl-devel`
+  + On Debian Buster: `apt-get install g++ unixodbc-dev python3-dev libssl-dev libffi-dev`
+  + On CentOS 8: `yum install gcc-c++ unixODBC-devel python38-devel libffi-devel openssl-devel`
 
 To check your version of python, run the `python` command
 ```

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -20,7 +20,7 @@ The soda-sql CLI requires the following dependencies to be installed on your sys
 - Python >=3.7 <3.9
 - Pip >=21.0
 - postgresql-libs (`libpq-dev` in Debian/Ubuntu, `libpq-devel` in CentOS, `postgresql` on MacOSX)
-- _Linux only:_ `libssl-dev` and `libffi-dev` (`libffi-devel` and `openssl-devel` in CentOS)
+- _Linux only:_ `g++`, `unixodbc-dev`, `python3-dev`, `libssl-dev` and `libffi-dev` (`libffi-devel` and `openssl-devel` in CentOS)
 
 To check your version of python, run the `python` command
 ```

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -20,7 +20,9 @@ The soda-sql CLI requires the following dependencies to be installed on your sys
 - Python >=3.7 <3.9
 - Pip >=21.0
 - postgresql-libs (`libpq-dev` in Debian/Ubuntu, `libpq-devel` in CentOS, `postgresql` on MacOSX)
-- _Linux only:_ `g++`, `unixodbc-dev`, `python3-dev`, `libssl-dev` and `libffi-dev` (`libffi-devel` and `openssl-devel` in CentOS)
+- _Linux only:_ 
+  + On Debian Buster: `g++`, `unixodbc-dev`, `python3-dev`, `libssl-dev` and `libffi-dev`
+  + On CentOS 8: `gcc-c++`, `unixODBC-devel`, `python38-devel`, `libffi-devel` and `openssl-devel`
 
 To check your version of python, run the `python` command
 ```

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -20,9 +20,12 @@ The soda-sql CLI requires the following dependencies to be installed on your sys
 - Python >=3.7 <3.9
 - Pip >=21.0
 - postgresql-libs (`libpq-dev` in Debian/Ubuntu, `libpq-devel` in CentOS, `postgresql` on MacOSX)
-- _Linux only:_ 
+- _Linux only:_
   + On Debian Buster: `apt-get install g++ unixodbc-dev python3-dev libssl-dev libffi-dev`
   + On CentOS 8: `yum install gcc-c++ unixODBC-devel python38-devel libffi-devel openssl-devel`
+
+- _MSSQLServer Warehouse only:_
+  + If you use MSSQLServer, make sure that you also install appropriate [SQLServer Driver](https://docs.microsoft.com/en-us/sql/connect/odbc/microsoft-odbc-driver-for-sql-server?view=sql-server-ver15)
 
 To check your version of python, run the `python` command
 ```


### PR DESCRIPTION
Updates the list of expected components on the Linux systems before soda-sql installation would be tried out.

@dirkgroenen I think you've added previously `openssl-dev` and `libffi-devel` but I am not sure if they are needed since docker image can execute scans (on postgresql database at least) without having these installed. Is there a way to quickly verify they are still needed? I didn't even have to install `libpq-dev` on docker image `python:3.8.5-slim-buster` and again soda-sql seems to be working OOTB.