### PR TITLE
bugfix: filter at the wrong place of histogram query

### DIFF
--- a/sodasql/scan/scan.py
+++ b/sodasql/scan/scan.py
@@ -391,9 +391,6 @@ class Scan:
                            f'  {fields} \n'
                            f'FROM group_by_value')
 
-                    if self.filter_sql:
-                        sql += f' \nWHERE {self.scan.filter_sql}'
-
                     row = self.warehouse.sql_fetchone(sql)
                     self.queries_executed += 1
 


### PR DESCRIPTION
In case of histogram queries, filter is already passed to the CTE.
Adding the filter to the query using the CTE as input cause an error as non of the columns given in the filter may exists in select statement.