### PR TITLE
Improve error handling in postgres/redshift

### DIFF
--- a/sodasql/dialects/postgres_dialect.py
+++ b/sodasql/dialects/postgres_dialect.py
@@ -101,6 +101,9 @@ class PostgresDialect(Dialect):
         error_message = str(exception)
         return error_message.find('Operation timed out') != -1 or \
                error_message.find('could not translate host name') != -1 or \
+               error_message.find('could not connect to server') != -1 or \
+               error_message.find('No route to host') != -1 or \
+               error_message.find('no route to host') != -1 or \
                error_message.find('timeout expired') != -1
 
     def is_authentication_error(self, exception):


### PR DESCRIPTION
Additional circumstances found where we should be able to detect errors connecting to Redshift or Postgres which were not caught using current set of heuristics.

1. AWS errors (wrong role id, erroneous AWS key pair etc) are handled as connection errors
2. other flavours of psycopg2 driver connection errors detected

closes sodadata/soda#1952
improves sodadata/soda#1953