### PR TITLE
reword output of `create` to point to `analyze`

### DIFF
--- a/sodasql/cli/cli.py
+++ b/sodasql/cli/cli.py
@@ -145,7 +145,7 @@ def create(warehouse_type: str,
             logging.info(
                 f"Review section {warehouse} in ~/.soda/env_vars.yml by running command")
             logging.info(f"  cat ~/.soda/env_vars.yml")
-        logging.info(f"Then run the soda init command")
+        logging.info(f"Then run the soda analyse command")
     except Exception as e:
         logging.exception(f'Exception: {str(e)}')
         return 1

--- a/sodasql/cli/cli.py
+++ b/sodasql/cli/cli.py
@@ -145,7 +145,7 @@ def create(warehouse_type: str,
             logging.info(
                 f"Review section {warehouse} in ~/.soda/env_vars.yml by running command")
             logging.info(f"  cat ~/.soda/env_vars.yml")
-        logging.info(f"Then run the soda analyse command")
+        logging.info(f"Then run the soda analyze command")
     except Exception as e:
         logging.exception(f'Exception: {str(e)}')
         return 1


### PR DESCRIPTION
# Description
Since we renamed the `init` task to `analyse` we might as well incentivise people to use that one directly instead to prevent them getting any future bumps with deprecations and whatnot
