### PR TITLE
Fixes #241 Fix BigQuery `soda create` command

### DIFF
--- a/packages/bigquery/sodasql/dialects/bigquery_dialect.py
+++ b/packages/bigquery/sodasql/dialects/bigquery_dialect.py
@@ -38,7 +38,7 @@ class BigQueryDialect(Dialect):
     def default_connection_properties(self, params: dict):
         return {
             KEY_WAREHOUSE_TYPE: BIGQUERY,
-            'account_info': 'env_var(BIGQUERY_ACCOUNT_INFO)',
+            'account_info_json': 'env_var(BIGQUERY_ACCOUNT_INFO)',
             'dataset': params.get('database', 'Eg your_bigquery_dataset')
         }
 
@@ -105,7 +105,10 @@ class BigQueryDialect(Dialect):
     @staticmethod
     def __parse_json_credential(credential_name, parser):
         try:
-            return json.loads(parser.get_credential(credential_name))
+            cred = parser.get_credential(credential_name)
+            # Prevent json load when the Dialect is init from create command
+            if cred is not None:
+                return json.loads(cred)
         except JSONDecodeError as e:
             parser.error(f'Error parsing credential {credential_name}: {e}', credential_name)
 

--- a/tests/cli/test_cli_commands.py
+++ b/tests/cli/test_cli_commands.py
@@ -25,10 +25,10 @@ class TestCLICommands(unittest.TestCase):
         assert result.exception is None
         assert result.exit_code == 0
 
-    # def test_create_bigquery(self):
-    #     result = self.runner.invoke(create, ['bigquery'])
-    #     assert result.exception is None
-    #     assert result.exit_code == 0
+    def test_create_bigquery(self):
+        result = self.runner.invoke(create, ['bigquery'])
+        assert result.exception is None
+        assert result.exit_code == 0
 
     def test_create_hive(self):
         result = self.runner.invoke(create, ['hive'])


### PR DESCRIPTION
Don't try to parse the json in the `soda create` code path. This will result in
error.