### PR TITLE
Add snowflake connection parameters

### DIFF
--- a/core/sodasql/scan/parser.py
+++ b/core/sodasql/scan/parser.py
@@ -145,6 +145,12 @@ class Parser:
     def get_float_optional(self, property_name: str, default=None):
         return self._get(property_name, float, False, default)
 
+    def get_bool_required(self, property_name: str):
+        return self._get(property_name, bool, True)
+
+    def get_bool_optional(self, property_name: str, default=None):
+        return self._get(property_name, bool, False, default)
+
     def get_dict_required(self, property_name: str):
         return self._get(property_name, dict, True)
 

--- a/packages/snowflake/sodasql/dialects/snowflake_dialect.py
+++ b/packages/snowflake/sodasql/dialects/snowflake_dialect.py
@@ -28,6 +28,12 @@ class SnowflakeDialect(Dialect):
             self.password = parser.get_credential('password')
             self.database = parser.get_str_optional_env('database')
             self.schema = parser.get_str_required_env('schema')
+            self.role = parser.get_str_optional('role')
+            self.passcode_in_password = parser.get_bool_optional('passcode_in_password', False)
+            self.private_key = parser.get_str_optional('private_key')
+            self.client_prefetch_threads = parser.get_int_optional('client_prefetch_threads', 4)
+            self.client_session_keep_alive = parser.get_bool_optional('client_session_keep_alive', False)
+            self.authenticator = parser.get_str_optional('authenticator', 'snowflake')
             self.connection_timeout = parser.get_int_optional(KEY_CONNECTION_TIMEOUT, DEFAULT_SOCKET_CONNECT_TIMEOUT)
 
     def default_connection_properties(self, params: dict):
@@ -57,6 +63,12 @@ class SnowflakeDialect(Dialect):
                 database=self.database,
                 schema=self.schema,
                 login_timeout=self.connection_timeout,
+                role=self.role,
+                passcode_in_password=self.passcode_in_password,
+                private_key=self.private_key,
+                client_prefetch_threads=self.client_prefetch_threads,
+                client_session_keep_alive=self.client_session_keep_alive,
+                authenticator=self.authenticator,
             )
             return conn
 


### PR DESCRIPTION
Most of the parameters now can be supplied in warehouse.yml
see: https://docs.snowflake.com/en/user-guide/python-connector-api.html#connect

Closes #283