### PR TITLE
Adds overridable limit clauses (for MS SQLServer)

### DIFF
--- a/core/sodasql/dataset_analyzer.py
+++ b/core/sodasql/dataset_analyzer.py
@@ -53,6 +53,7 @@ class DatasetAnalyzer:
             analyze_results.append(column_analysis_result)
 
             qualified_column_name = dialect.qualify_column_name(column_name)
+            select_with_limit_query = dialect.sql_select_with_limit(qualified_table_name, 1000)
 
             if dialect.is_text(source_type):
                 column_analysis_result.is_text = True
@@ -72,7 +73,7 @@ class DatasetAnalyzer:
                     f'SELECT \n  ' +
                     (',\n  '.join(validity_format_count_fields)) + ',\n'
                     f'  COUNT({qualified_column_name}) \n'
-                    f'FROM (SELECT * FROM {qualified_table_name} LIMIT 1000) T'
+                    f'FROM ({select_with_limit_query}) T'
                 )
 
                 values_count = row[len(validity_counts)]

--- a/core/sodasql/scan/dialect.py
+++ b/core/sodasql/scan/dialect.py
@@ -194,6 +194,12 @@ class Dialect:
     def sql_expr_regexp_like(self, expr: str, pattern: str):
         return f"REGEXP_LIKE({expr}, '{self.qualify_regex(pattern)}')"
 
+    def sql_expr_limit(self, count):
+        return f'LIMIT {count}'
+
+    def sql_select_with_limit(self, table_name, count):
+        return f'SELECT * FROM {table_name} LIMIT {count}'
+
     def sql_expr_list(self, column: ColumnMetadata, values: List[str]) -> str:
         if self.is_text(column.type):
             sql_values = [self.literal_string(value) for value in values]

--- a/core/sodasql/scan/scan.py
+++ b/core/sodasql/scan/scan.py
@@ -325,7 +325,7 @@ class Scan:
                                f'SELECT value \n'
                                f'FROM group_by_value \n'
                                f'ORDER BY {order_by_value_expr} ASC \n'
-                               f'LIMIT {scan_column.mins_maxs_limit} \n')
+                               f'{self.dialect.sql_expr_limit(scan_column.mins_maxs_limit)}\n')
 
                         rows = self.warehouse.sql_fetchall(sql)
                         self.queries_executed += 1
@@ -339,7 +339,7 @@ class Scan:
                                f'SELECT value \n'
                                f'FROM group_by_value \n'
                                f'ORDER BY {order_by_value_expr} DESC \n'
-                               f'LIMIT {scan_column.mins_maxs_limit} \n')
+                               f'{self.dialect.sql_expr_limit(scan_column.mins_maxs_limit)}\n')
 
                         rows = self.warehouse.sql_fetchall(sql)
                         self.queries_executed += 1
@@ -354,7 +354,7 @@ class Scan:
                                f'SELECT value, frequency \n'
                                f'FROM group_by_value \n'
                                f'ORDER BY frequency DESC \n'
-                               f'LIMIT {frequent_values_limit} \n')
+                               f'{self.dialect.sql_expr_limit(scan_column.mins_maxs_limit)}\n')
 
                         rows = self.warehouse.sql_fetchall(sql)
                         self.queries_executed += 1

--- a/packages/sqlserver/sodasql/dialects/sqlserver_dialect.py
+++ b/packages/sqlserver/sodasql/dialects/sqlserver_dialect.py
@@ -113,7 +113,7 @@ class SQLServerDialect(Dialect):
         return f'"{table_name}"'
 
     def sql_expr_regexp_like(self, expr: str, pattern: str):
-        return f"{expr} ~* '{self.qualify_regex(pattern)}'"
+        return f"{expr} LIKE '{self.qualify_regex(pattern)}'"
 
     def sql_expr_length(self, expr):
         return f'LEN({expr})'
@@ -123,6 +123,12 @@ class SQLServerDialect(Dialect):
 
     def sql_expr_stddev(self, expr: str):
         return f'STDEV({expr})'
+
+    def sql_expr_limit(self, count):
+        return f'OFFSET 0 ROWS FETCH NEXT {count} ROWS ONLY'
+
+    def sql_select_with_limit(self, table_name, count):
+        return f'SELECT TOP {count} * FROM {table_name}'
 
     # TODO REGEX not supported by SQL SERVER
     def sql_expr_cast_text_to_number(self, quoted_column_name, validity_format):


### PR DESCRIPTION
SQLServer doesn't have LIMIT, which needs to be replaced by `SELECT TOP` and
when there is an `ORDER BY` 'OFFSET / NEXT` should be used.

closes #159 closes #281