### PR TITLE
Remove introspecting for dates in sql expression filter

### DIFF
--- a/core/sodasql/scan/dialect.py
+++ b/core/sodasql/scan/dialect.py
@@ -293,17 +293,7 @@ class Dialect:
             else:
                 raise RuntimeError('Unsupported time comparison! Only "scanTime" is supported')
         elif type == 'columnValue':
-            column_name = expression_dict['columnName']
-            scan_columns = kwargs.get('scan_columns')
-            if scan_columns is not None:
-                scan_column = scan_columns.get(column_name)
-                # TODO make sure that all varchar as some other data types are cast properly
-                if scan_column.is_column_temporal_text_format:
-                    sql = f"CAST ({expression_dict['columnName']} AS DATE)"
-                else:
-                    sql = expression_dict['columnName']
-            else:
-                sql = expression_dict['columnName']
+            sql = expression_dict['columnName']
         elif type == 'collection':
             # collection of string or number literals
             value = expression_dict['value']

--- a/core/sodasql/soda_server_client/monitor_metric_parser.py
+++ b/core/sodasql/soda_server_client/monitor_metric_parser.py
@@ -38,8 +38,7 @@ class MonitorMetricParser(Parser):
                 qualified_group_column_names = [self.dialect.qualify_column_name(group_field)
                                                 for group_field in group_by_column_names]
             filter_condition = self.dialect.sql_expression(expression_dict=filter_expression_dict,
-                                                           scan_time=scan.time,
-                                                           scan_columns=scan.scan_columns)
+                                                           scan_time=scan.time)
 
             self.monitor_metric.build_sql(
                 qualified_group_column_names,

--- a/tests/local/warehouse/samples/test_samples_and_failed_rows.py
+++ b/tests/local/warehouse/samples/test_samples_and_failed_rows.py
@@ -81,7 +81,11 @@ class TestSamplesAndFailedRows(SqlTestCase):
                     'tests': [
                         'invalid_count == 0'
                     ]
+                },
+                'date': {
+                    'valid_format': 'date_eu'
                 }
+
             },
             'sql_metrics': [
                 {


### PR DESCRIPTION
This is causing issues with casting, for now we rely on the default behaviour of
string comparison for dates.

Needs more time/effort to design more robust solution.

Closes #330