### PR TITLE
Skips tests when any of the corresponding metrics are null

### DIFF
--- a/core/sodasql/scan/test_result.py
+++ b/core/sodasql/scan/test_result.py
@@ -18,15 +18,21 @@ from sodasql.scan.test import Test
 
 @dataclass
 class TestResult:
-
     test: Test
     passed: bool
+    skipped: bool
     values: Optional[dict] = None
     error: Optional[Exception] = None
     group_values: Optional[dict] = None
 
     def __str__(self):
-        return (f'Test {self.test.title} {"passed" if self.passed else "failed"}' +
+        if self.passed:
+            status_str = 'passed'
+        elif self.skipped:
+            status_str = 'skipped'
+        else:
+            status_str = 'failed'
+        return (f'Test {self.test.title} {status_str}' +
                 (f" with group values {self.group_values}" if self.group_values else '') +
                 f' with measurements {json.dumps(JsonHelper.to_jsonnable(self.values))}')
 
@@ -39,7 +45,7 @@ class TestResult:
         test_result_json = {
             'id': self.test.id,
             'title': self.test.title,
-            'description': self.test.title, # for backwards compatibility
+            'description': self.test.title,  # for backwards compatibility
             'expression': self.test.expression
         }
 
@@ -50,6 +56,7 @@ class TestResult:
             test_result_json['error'] = str(self.error)
         else:
             test_result_json['passed'] = self.passed
+            test_result_json['skipped'] = self.skipped
             test_result_json['values'] = JsonHelper.to_jsonnable(self.values)
 
         if self.group_values:

--- a/tests/local/warehouse/metrics/test_all_table_metrics.py
+++ b/tests/local/warehouse/metrics/test_all_table_metrics.py
@@ -10,7 +10,7 @@
 #  limitations under the License.
 
 from sodasql.scan.metric import Metric
-from sodasql.scan.scan_yml_parser import KEY_METRIC_GROUPS
+from sodasql.scan.scan_yml_parser import KEY_METRIC_GROUPS, KEY_METRICS, KEY_COLUMNS, COLUMN_KEY_TESTS
 from tests.common.sql_test_case import SqlTestCase
 from decimal import *
 
@@ -311,3 +311,23 @@ class TestMetricGroups(SqlTestCase):
         self.assertEqual(scan_result.get(Metric.VALUES_PERCENTAGE), 91.66666666666667)
         self.assertAlmostEqual(scan_result.get(Metric.VARIANCE), Decimal(1.2000), 4)
         self.assertEqual(24, len(scan_result.measurements))
+
+    def test_empty_table_metrics(self):
+        self.sql_recreate_table(
+            [f"score {self.dialect.data_type_integer}"])
+
+        scan_result = self.scan({
+            KEY_METRICS: [
+                Metric.MAX,
+                Metric.ROW_COUNT
+            ],
+            KEY_COLUMNS: {
+                'score': {
+                    COLUMN_KEY_TESTS: [
+                        'max == None',
+                        'max < 5'
+                    ]
+                }
+            }
+        })
+


### PR DESCRIPTION
Tests that do with None comparison will still work, on the other hand when the
metric is null, the tests will be skipped with a warning on the console

Closes #334