### PR TITLE
Adding event dispatch for two depending repo's

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,3 +143,24 @@ jobs:
         run: |
           pip3 install -r requirements.txt
           python3 report_release_success.py
+  ping-repos:
+    name: Dispatch repos
+    needs: [ inform-release-success ]
+    timeout-minutes: 10
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        deploy-environment: [ LDA, SCS ]
+        include:
+          - deploy-environment: LDA
+            targetrepo: sodadata/live-data-accessor
+          - deploy-environment: SCS
+            targetrepo: sodadata/cloud-scanner
+    steps:
+      - name: Repository Dispatch
+        uses: sodadata/repository-dispatch@v1
+        with:
+          token: ${{ secrets.REPO_ACCESS_TOKEN_DISPATCH }}
+          repository: ${{ matrix.targetrepo }}
+          event-type: started-from-soda-sql
+          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'


### PR DESCRIPTION
Dispatch an event to two internal repositories which may then decide to start a new build with latest soda-sql.