### PR TITLE
Add docker compose for spark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,7 +130,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
-*.xml
 reports/*
 !reports/index.html
 

--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,6 @@ dmypy.json
 reports/*
 !reports/index.html
 
+# Spark
+.hive-metastore/
+.spark-warehouse/

--- a/scripts/start_spark_container.sh
+++ b/scripts/start_spark_container.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+# run this from the root project dir with scripts/start_spark_container.sh
+
+( cd tests/spark_container ; docker-compose up )

--- a/tests/spark_container/docker-compose.yml
+++ b/tests/spark_container/docker-compose.yml
@@ -1,0 +1,26 @@
+version: "3.7"
+services:
+  spark2-thrift:
+    image: godatadriven/spark:2
+    ports:
+      - "10000:10000"
+      - "4040:4040"
+    depends_on:
+      - hive-metastore
+    command: >
+      --class org.apache.spark.sql.hive.thriftserver.HiveThriftServer2
+      --name Thrift JDBC/ODBC Server
+    volumes:
+      - ./.spark-warehouse/:/spark-warehouse/
+      - ./docker/hive-site.xml:/usr/spark/conf/hive-site.xml
+    environment:
+      - WAIT_FOR=hive-metastore:5432
+
+  hive-metastore:
+    image: postgres:9.6.17-alpine
+    volumes:
+      - ./.hive-metastore/:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_USER=soda
+      - POSTGRES_PASSWORD=soda
+      - POSTGRES_DB=metastore

--- a/tests/spark_container/docker-compose.yml
+++ b/tests/spark_container/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       --name Thrift JDBC/ODBC Server
     volumes:
       - ./.spark-warehouse/:/spark-warehouse/
-      - ./docker/hive-site.xml:/usr/spark/conf/hive-site.xml
+      - ./hive-site.xml:/usr/spark/conf/hive-site.xml
     environment:
       - WAIT_FOR=hive-metastore:5432
 

--- a/tests/spark_container/hive-site.xml
+++ b/tests/spark_container/hive-site.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+     Licensed to the Apache Software Foundation (ASF) under one or more
+     contributor license agreements.  See the NOTICE file distributed with
+     this work for additional information regarding copyright ownership.
+     The ASF licenses this file to You under the Apache License, Version 2.0
+     (the "License"); you may not use this file except in compliance with
+     the License.  You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<configuration>
+
+    <property>
+        <name>javax.jdo.option.ConnectionURL</name>
+        <value>jdbc:postgresql://hive-metastore/metastore</value>
+    </property>
+
+    <property>
+        <name>javax.jdo.option.ConnectionDriverName</name>
+        <value>org.postgresql.Driver</value>
+    </property>
+
+    <property>
+        <name>javax.jdo.option.ConnectionUserName</name>
+        <value>soda</value>
+    </property>
+
+    <property>
+        <name>javax.jdo.option.ConnectionPassword</name>
+        <value>soda</value>
+    </property>
+
+</configuration>


### PR DESCRIPTION
Adds a docker-compose file for running Spark. To be used for testing Soda spark.