### PR TITLE
Fix is_number detection in Athena

### DIFF
--- a/packages/athena/sodasql/dialects/athena_dialect.py
+++ b/packages/athena/sodasql/dialects/athena_dialect.py
@@ -79,7 +79,7 @@ class AthenaDialect(Dialect):
 
     def is_number(self, column_type: str):
         column_type_upper = column_type.upper()
-        return (column_type_upper in ['TINYINT', 'SMALLINT', 'INT', 'INTEGER', 'BIGINT', 'DOUBLE', 'FLOAT', 'DECIMAL']
+        return (column_type_upper in ['TINYINT', 'SMALLINT', 'INT', 'INTEGER', 'BIGINT', 'DOUBLE', 'FLOAT', 'REAL', 'DECIMAL']
                 or re.match(r'^DECIMAL\([0-9]+(,[0-9]+)?\)$', column_type_upper))
 
     def is_time(self, column_type: str):


### PR DESCRIPTION
The next query returns REAL type even if a table has float/double type.

```SELECT column_name, data_type, is_nullable 
FROM information_schema.columns 
WHERE table_name = '...' 
  AND table_schema = '...';
  ```