### PR TITLE
Add authentication config parameter to hive

### DIFF
--- a/packages/hive/sodasql/dialects/hive_dialect.py
+++ b/packages/hive/sodasql/dialects/hive_dialect.py
@@ -16,7 +16,8 @@ class HiveDialect(Dialect):
             self.host = parser.get_str_required('host')
             self.port = parser.get_int_optional('port', '10000')
             self.username = parser.get_str_required_env('username')
-            self.password = parser.get_str_required_env('password')
+            self.password = parser.get_str_optional_env('password')
+            self.auth_method = parser.get_str_optional('authentication', None)
             self.database = parser.get_str_optional('database', 'default')
             self.configuration = parser.get_dict_optional('configuration')
 
@@ -52,7 +53,7 @@ class HiveDialect(Dialect):
                 # https://github.com/jaegertracing/jaeger-client-python/issues/151
                 configuration={key: str(value)
                                for key, value in self.configuration.items()},
-                auth=None)
+                auth=self.auth_method)
             return conn
         except Exception as e:
             self.try_to_raise_soda_sql_exception(e)


### PR DESCRIPTION
`authentication` can be set to LDAP, which defaults to None. The password is an
optional parameter.

Closes #368