### PR TITLE
make the recreate_venv.sh script work again

### DIFF
--- a/scripts/recreate_venv.sh
+++ b/scripts/recreate_venv.sh
@@ -13,8 +13,6 @@ python3 -m venv $VENV_DIR
 source $VENV_DIR/bin/activate
 pip install --upgrade pip
 pip install "$(cat dev-requirements.in | grep pip-tools)"
-pip-compile requirements.in
 pip-compile dev-requirements.in
-pip install -r requirements.txt
 pip install -r dev-requirements.txt
-pip install -e .
+pip install -r requirements.txt


### PR DESCRIPTION
Script `scripts/recreate_venv.sh` stopped working at some moment in time.

I have also noticed that the `clean_install.sh` is not operational any more as well:

```
➜ scripts/clean-install.sh
Found existing installation: soda-sql-core 2.1.0b11
Uninstalling soda-sql-core-2.1.0b11:
  Successfully uninstalled soda-sql-core-2.1.0b11
python: can't open file 'setup.py': [Errno 2] No such file or directory
ERROR: Directory '.' is not installable. Neither 'setup.py' nor 'pyproject.toml' found.
```

But I am not sure I understand in which flow should it be used so I decided not to try to fix that one as well