### PR TITLE
Updates log level from error to warning for columns with unsupported …

### DIFF
--- a/core/sodasql/scan/scan.py
+++ b/core/sodasql/scan/scan.py
@@ -182,7 +182,7 @@ class Scan:
                               f'{"" if scan_column.column.nullable else "not null"}')
                 self.scan_columns[column_metadata.name.lower()] = scan_column
             else:
-                logging.error(f'  {scan_column.column_name} ({scan_column.column.data_type}) -> unsupported, skipped!')
+                logging.info(f'  {scan_column.column_name} ({scan_column.column.data_type}) -> unsupported, skipped!')
 
         logging.debug(str(len(self.column_metadatas)) + ' columns:')
 

--- a/examples/aws-lambda/lambda-zip/package/sodasql/scan/scan.py
+++ b/examples/aws-lambda/lambda-zip/package/sodasql/scan/scan.py
@@ -181,7 +181,7 @@ class Scan:
                               f'{"" if scan_column.column.nullable else "not null"}')
                 self.scan_columns[column_metadata.name.lower()] = scan_column
             else:
-                logging.error(f'  {scan_column.column_name} ({scan_column.column.data_type}) -> unsupported, skipped!')
+                logging.info(f'  {scan_column.column_name} ({scan_column.column.data_type}) -> unsupported, skipped!')
 
         logging.debug(str(len(self.column_metadatas)) + ' columns:')
 


### PR DESCRIPTION
Issue
---
- Columns with unsupported data types logs the message as an error
- Per the Python docs, an `error` log level should only be used "when there is a more serious problem, the software has not been able to perform some function."
- The use of the error log level leads to errors bubbling up incorrectly in application monitoring and error tracking software, such as Sentry

Resolution
---
- Per the Python docs, as the system is functioning as expected - the feature is merely unsupported yet - the most appropriate log level for this is `info`. See docs [here](https://docs.python.org/3/howto/logging.html)
- Updates the logging to be at the `info` level

--
 

<br class="Apple-interchange-newline">`