### PR TITLE
Add excluded_columns feature

### DIFF
--- a/core/sodasql/scan/scan.py
+++ b/core/sodasql/scan/scan.py
@@ -166,24 +166,29 @@ class Scan:
         self.scan_columns: dict = {}
         self.column_names: List[str] = [column_metadata.name for column_metadata in self.column_metadatas]
         for column_metadata in self.column_metadatas:
-            scan_column = ScanColumn(self, column_metadata)
-            if scan_column.is_supported:
-                if scan_column.is_numeric:
-                    column_metadata.logical_type = 'number'
-                elif scan_column.is_temporal:
-                    column_metadata.logical_type = 'time'
-                # WARN: Order of conditions is important here, because the is_text is based on database data type,
-                # and is_numeric, is_temporal are calculated based on validity format. So both is_text and
-                # (is_temporal|is_numeric) can be true.
-                elif scan_column.is_text:
-                    column_metadata.logical_type = 'text'
+            if (self.scan_yml.excluded_columns is not None) and (
+                  column_metadata.name in self.scan_yml.excluded_columns):
+                logging.info(f'  column {column_metadata.name} is excluded based on configuration!')
 
-                logging.debug(f'  {scan_column.column_name} ({scan_column.column.data_type}) '
-                              f'{"" if scan_column.column.nullable else "not null"}')
-                self.scan_columns[column_metadata.name.lower()] = scan_column
             else:
-                logging.info(f'  {scan_column.column_name} ({scan_column.column.data_type}) -> unsupported, skipped!')
+                scan_column = ScanColumn(self, column_metadata)
+                if scan_column.is_supported:
+                    if scan_column.is_numeric:
+                        column_metadata.logical_type = 'number'
+                    elif scan_column.is_temporal:
+                        column_metadata.logical_type = 'time'
+                    # WARN: Order of conditions is important here, because the is_text is based on database data type,
+                    # and is_numeric, is_temporal are calculated based on validity format. So both is_text and
+                    # (is_temporal|is_numeric) can be true.
+                    elif scan_column.is_text:
+                        column_metadata.logical_type = 'text'
 
+                    logging.debug(f'  {scan_column.column_name} ({scan_column.column.data_type}) '
+                                  f'{"" if scan_column.column.nullable else "not null"}')
+                    self.scan_columns[column_metadata.name.lower()] = scan_column
+                else:
+                    logging.info(
+                        f'  {scan_column.column_name} ({scan_column.column.data_type}) -> unsupported, skipped!')
         logging.debug(str(len(self.column_metadatas)) + ' columns:')
 
         # Compare the column names in yml with valid column names from the table

--- a/core/sodasql/scan/scan_yml.py
+++ b/core/sodasql/scan/scan_yml.py
@@ -27,6 +27,7 @@ class ScanYml:
     tests: List[Test] = None
     # maps column_name.lower() to ScanYamlColumn's
     columns: dict = None
+    excluded_columns: list = None
     filter: str = None
     filter_template: Template = None
     sample_percentage: float = None

--- a/core/sodasql/scan/scan_yml_parser.py
+++ b/core/sodasql/scan/scan_yml_parser.py
@@ -30,6 +30,7 @@ KEY_METRIC_GROUPS = 'metric_groups'
 KEY_SQL_METRICS = 'sql_metrics'
 KEY_TESTS = 'tests'
 KEY_COLUMNS = 'columns'
+KEY_EXCLUDED_COLUMNS = 'excluded_columns'
 KEY_MINS_MAXS_LIMIT = 'mins_maxs_limit'
 KEY_FREQUENT_VALUES_LIMIT = 'frequent_values_limit'
 KEY_SAMPLE_PERCENTAGE = 'sample_percentage'
@@ -39,7 +40,7 @@ KEY_SAMPLES = 'samples'
 
 VALID_SCAN_YML_KEYS = [KEY_TABLE_NAME, KEY_METRICS, KEY_METRIC_GROUPS, KEY_SQL_METRICS,
                        KEY_TESTS, KEY_COLUMNS, KEY_MINS_MAXS_LIMIT, KEY_FREQUENT_VALUES_LIMIT,
-                       KEY_SAMPLE_PERCENTAGE, KEY_SAMPLE_METHOD, KEY_FILTER, KEY_SAMPLES]
+                       KEY_SAMPLE_PERCENTAGE, KEY_SAMPLE_METHOD, KEY_FILTER, KEY_SAMPLES, KEY_EXCLUDED_COLUMNS]
 
 COLUMN_KEY_METRICS = KEY_METRICS
 COLUMN_KEY_METRIC_GROUPS = KEY_METRIC_GROUPS
@@ -117,6 +118,7 @@ class ScanYmlParser(Parser):
         table_name = self.get_str_required(KEY_TABLE_NAME)
         self.scan_yml.table_name = table_name
         self.scan_yml.metrics = self.parse_metrics()
+        self.scan_yml.excluded_columns = self.get_list_optional(KEY_EXCLUDED_COLUMNS)
 
         self.scan_yml.sql_metric_ymls = self.parse_sql_metric_ymls(KEY_SQL_METRICS)
 

--- a/tests/local/warehouse/scans/test_columns_exclusion.py
+++ b/tests/local/warehouse/scans/test_columns_exclusion.py
@@ -1,0 +1,42 @@
+#   Copyright 2020 Soda
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#    http://www.apache.org/licenses/LICENSE-2.0
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+from sodasql.scan.scan_yml_parser import KEY_METRICS, KEY_EXCLUDED_COLUMNS
+from tests.common.sql_test_case import SqlTestCase
+
+
+class TestColumnsExclusion(SqlTestCase):
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.sql_recreate_table(
+            [f"one {self.dialect.data_type_varchar_255}", f"two {self.dialect.data_type_varchar_255}"],
+            ["('a', 'alpha')",
+             "('b', 'beta')",
+             "('c', 'gamma') ",
+             "('d', 'delta')",
+             "(null, null)"])
+
+    def test_scan_result_with_test_error(self):
+        scan_yml_dict = {
+            KEY_EXCLUDED_COLUMNS: [
+                "two"
+            ],
+            KEY_METRICS: [
+                'row_count',
+                'missing_count'
+            ]
+
+        }
+        scan_result = self.scan(scan_yml_dict)
+        self.assertIsNotNone(scan_result.get_measurement('missing_count', 'one'))
+        with self.assertRaises(AssertionError):
+            scan_result.get_measurement('missing_count', 'two')


### PR DESCRIPTION
Scan YAML now can optionally contain `excluded_columns` list to prevent soda
scan scanning those columns

```YAML
excluded_columns:
  - one
  - two
```