### PR TITLE
Issue/402

### DIFF
--- a/core/sodasql/common/yaml_helper.py
+++ b/core/sodasql/common/yaml_helper.py
@@ -14,10 +14,10 @@ class YamlHelper:
 
     @staticmethod
     def validate_numeric_value(column_name, key, value):
-        if column_name is None:
+        if value is None:
             print("column none")
             logging.info(f'There is no {column_name} key to be validated')
-        elif value is None or not isinstance(value, int):
+        elif value is not isinstance(value, int):
             logging.error(f'{column_name} could not be parsed: {key}-{value} is not of a numeric type.')
             raise Exception(f'{column_name} could not be parsed: {key}-{value} is not of a numeric type.')
         else:

--- a/core/sodasql/common/yaml_helper.py
+++ b/core/sodasql/common/yaml_helper.py
@@ -17,7 +17,7 @@ class YamlHelper:
         if value is None:
             print("column none")
             logging.info(f'There is no {column_name} key to be validated')
-        elif value is not isinstance(value, int):
+        elif value is isinstance(value, int):
             logging.error(f'{column_name} could not be parsed: {key}-{value} is not of a numeric type.')
             raise Exception(f'{column_name} could not be parsed: {key}-{value} is not of a numeric type.')
         else:

--- a/core/sodasql/common/yaml_helper.py
+++ b/core/sodasql/common/yaml_helper.py
@@ -17,5 +17,5 @@ class YamlHelper:
         if value is not None and isinstance(value, int):
             return value
         else:
-            logging.error(f'{column_name} could not be parsed: {value} is not of a numeric type.')
+            logging.warning(f'{column_name} could not be parsed: {value} is not of a numeric type.')
             raise Exception(f'{column_name} could not be parsed: {key}-{value} is not of a numeric type.')

--- a/core/sodasql/common/yaml_helper.py
+++ b/core/sodasql/common/yaml_helper.py
@@ -18,7 +18,7 @@ class YamlHelper:
             return value
         else:
             logging.error(f'{column_name} could not be parsed: {key}-{value} is not of a numeric type.')
-
+            raise Exception(f'{column_name} could not be parsed: {key}-{value} is not of a numeric type.')
 
     @staticmethod
     def validate_array_value(column_name, key, value):

--- a/core/sodasql/common/yaml_helper.py
+++ b/core/sodasql/common/yaml_helper.py
@@ -22,7 +22,6 @@ class YamlHelper:
         else:
             return value
 
-
     @staticmethod
     def validate_array_value(column_name, key, value):
         if value is None:

--- a/core/sodasql/common/yaml_helper.py
+++ b/core/sodasql/common/yaml_helper.py
@@ -14,10 +14,15 @@ class YamlHelper:
 
     @staticmethod
     def validate_numeric_value(column_name, key, value):
-        if value is not None and isinstance(value, int):
-            return value
-        else:
+        if key is None:
+            print("key none")
+            logging.info(f'There is no {key} key to be validated')
+        elif value is None or not isinstance(value, int):
             logging.error(f'{column_name} could not be parsed: {key}-{value} is not of a numeric type.')
+            raise Exception(f'{column_name} could not be parsed: {key}-{value} is not of a numeric type.')
+        else:
+            return value
+
 
     @staticmethod
     def validate_array_value(column_name, key, value):

--- a/core/sodasql/common/yaml_helper.py
+++ b/core/sodasql/common/yaml_helper.py
@@ -14,9 +14,9 @@ class YamlHelper:
 
     @staticmethod
     def validate_numeric_value(column_name, key, value):
-        if key is None:
-            print("key none")
-            logging.info(f'There is no {key} key to be validated')
+        if column_name is None:
+            print("column none")
+            logging.info(f'There is no {column_name} key to be validated')
         elif value is None or not isinstance(value, int):
             logging.error(f'{column_name} could not be parsed: {key}-{value} is not of a numeric type.')
             raise Exception(f'{column_name} could not be parsed: {key}-{value} is not of a numeric type.')

--- a/core/sodasql/common/yaml_helper.py
+++ b/core/sodasql/common/yaml_helper.py
@@ -13,10 +13,9 @@ class YamlHelper:
             logging.error(f'Parsing YAML failed: {str(e)}: ({description if description else yaml_str})xWW4')
 
     @staticmethod
-    def validate_numeric_value(column_name, value):
-        if isinstance(value, int):
-            logging.info("all good!")
+    def validate_numeric_value(column_name, key, value):
+        if value is not None and isinstance(value, int):
             return value
         else:
             logging.error(f'{column_name} could not be parsed: {value} is not of a numeric type.')
-            sys.exit(1)
+            raise Exception(f'{column_name} could not be parsed: {key}-{value} is not of a numeric type.')

--- a/core/sodasql/common/yaml_helper.py
+++ b/core/sodasql/common/yaml_helper.py
@@ -15,8 +15,7 @@ class YamlHelper:
     @staticmethod
     def validate_numeric_value(column_name, key, value):
         if value is None:
-            print("column none")
-            logging.info(f'There is no {column_name} key to be validated')
+            logging.info(f'There is no {key} key of this column name {column_name} to be validated')
         elif value is isinstance(value, int):
             logging.error(f'{column_name} could not be parsed: {key}-{value} is not of a numeric type.')
             raise Exception(f'{column_name} could not be parsed: {key}-{value} is not of a numeric type.')
@@ -26,7 +25,10 @@ class YamlHelper:
 
     @staticmethod
     def validate_array_value(column_name, key, value):
-        if value is not None and isinstance(value, list):
-            return value
+        if value is None:
+            logging.info(f'There is no {key} key of this column name {column_name} to be validated')
+        elif value is isinstance(value, list):
+            logging.error(f'{column_name} could not be parsed: {key}-{value} is not of a list type.')
+            raise Exception(f'{column_name} could not be parsed: {key}-{value} is not of a list type.')
         else:
-            logging.error(f'{column_name} could not be parsed: {key}-{value} is not a list.')
+            return value

--- a/core/sodasql/common/yaml_helper.py
+++ b/core/sodasql/common/yaml_helper.py
@@ -18,4 +18,4 @@ class YamlHelper:
             return value
         else:
             logging.warning(f'{column_name} could not be parsed: {value} is not of a numeric type.')
-            raise Exception(f'{column_name} could not be parsed: {key}-{value} is not of a numeric type.')
+            #raise Exception(f'{column_name} could not be parsed: {key}-{value} is not of a numeric type.')

--- a/core/sodasql/common/yaml_helper.py
+++ b/core/sodasql/common/yaml_helper.py
@@ -18,8 +18,7 @@ class YamlHelper:
             return value
         else:
             logging.error(f'{column_name} could not be parsed: {key}-{value} is not of a numeric type.')
-            raise Exception(f'{column_name} could not be parsed: {key}-{value} is not of a numeric type.')
-
+            
     @staticmethod
     def validate_array_value(column_name, key, value):
         if value is not None and isinstance(value, list):

--- a/core/sodasql/common/yaml_helper.py
+++ b/core/sodasql/common/yaml_helper.py
@@ -1,7 +1,7 @@
 import logging
 
 import yaml
-import sys
+
 
 class YamlHelper:
 
@@ -18,7 +18,7 @@ class YamlHelper:
             return value
         else:
             logging.error(f'{column_name} could not be parsed: {key}-{value} is not of a numeric type.')
-            
+
     @staticmethod
     def validate_array_value(column_name, key, value):
         if value is not None and isinstance(value, list):

--- a/core/sodasql/common/yaml_helper.py
+++ b/core/sodasql/common/yaml_helper.py
@@ -15,7 +15,7 @@ class YamlHelper:
     @staticmethod
     def validate_numeric_value(column_name, key, value):
         if value is None:
-            logging.info(f'There is no {key} key of this column name {column_name} to be validated')
+            logging.info(f'There is no value specified for {key} for column {column_name}')
         elif value is isinstance(value, int):
             logging.error(f'{column_name} could not be parsed: {key}-{value} is not of a numeric type.')
             raise Exception(f'{column_name} could not be parsed: {key}-{value} is not of a numeric type.')
@@ -23,9 +23,9 @@ class YamlHelper:
             return value
 
     @staticmethod
-    def validate_array_value(column_name, key, value):
+    def validate_list_value(column_name, key, value):
         if value is None:
-            logging.info(f'There is no {key} key of this column name {column_name} to be validated')
+            logging.info(f'There is no value specified for {key} for column {column_name}')
         elif value is isinstance(value, list):
             logging.error(f'{column_name} could not be parsed: {key}-{value} is not of a list type.')
             raise Exception(f'{column_name} could not be parsed: {key}-{value} is not of a list type.')

--- a/core/sodasql/common/yaml_helper.py
+++ b/core/sodasql/common/yaml_helper.py
@@ -1,7 +1,7 @@
 import logging
 
 import yaml
-
+import sys
 
 class YamlHelper:
 
@@ -11,3 +11,12 @@ class YamlHelper:
             return yaml.load(yaml_str, Loader=yaml.SafeLoader)
         except Exception as e:
             logging.error(f'Parsing YAML failed: {str(e)}: ({description if description else yaml_str})xWW4')
+
+    @staticmethod
+    def validate_numeric_value(column_name, value):
+        if isinstance(value, int):
+            logging.info("all good!")
+            return value
+        else:
+            logging.error(f'{column_name} could not be parsed: {value} is not of a numeric type.')
+            sys.exit(1)

--- a/core/sodasql/common/yaml_helper.py
+++ b/core/sodasql/common/yaml_helper.py
@@ -17,5 +17,12 @@ class YamlHelper:
         if value is not None and isinstance(value, int):
             return value
         else:
-            logging.warning(f'{column_name} could not be parsed: {value} is not of a numeric type.')
-            #raise Exception(f'{column_name} could not be parsed: {key}-{value} is not of a numeric type.')
+            logging.error(f'{column_name} could not be parsed: {key}-{value} is not of a numeric type.')
+
+
+    @staticmethod
+    def validate_array_value(column_name, key, value):
+        if value is not None and isinstance(value, list):
+            return value
+        else:
+            logging.error(f'{column_name} could not be parsed: {key}-{value} is not a list.')

--- a/core/sodasql/scan/scan_error.py
+++ b/core/sodasql/scan/scan_error.py
@@ -40,12 +40,10 @@ class SodaCloudScanError(ScanError):
     def get_type(self) -> str:
         return 'soda_cloud_error'
 
-
 @dataclass
 class WarehouseAuthenticationScanError(ScanError):
     def get_type(self) -> str:
         return 'warehouse_authentication_error'
-
 
 @dataclass
 class WarehouseConnectionScanError(ScanError):

--- a/core/sodasql/scan/scan_yml_parser.py
+++ b/core/sodasql/scan/scan_yml_parser.py
@@ -257,7 +257,7 @@ class ScanYmlParser(Parser):
                         self.warning(f'Invalid {column_name}.{COLUMN_KEY_VALID_FORMAT}: {validity.format}')
                     validity.regex = column_dict.get(COLUMN_KEY_VALID_REGEX)
                     validity.values = column_dict.get(COLUMN_KEY_VALID_VALUES)
-                    validity.min = YamlHelper.validate_numeric_value(column_dict.get(COLUMN_KEY_VALID_MIN))
+                    validity.min = column_dict.get(COLUMN_KEY_VALID_MIN)
                     validity.max = column_dict.get(COLUMN_KEY_VALID_MAX)
                     validity.min_length = column_dict.get(COLUMN_KEY_VALID_MIN_LENGTH)
                     validity.max_length = column_dict.get(COLUMN_KEY_VALID_MAX_LENGTH)

--- a/core/sodasql/scan/scan_yml_parser.py
+++ b/core/sodasql/scan/scan_yml_parser.py
@@ -255,8 +255,8 @@ class ScanYmlParser(Parser):
                     if validity.format is not None and Validity.FORMATS.get(validity.format) is None:
                         self.warning(f'Invalid {column_name}.{COLUMN_KEY_VALID_FORMAT}: {validity.format}')
                     validity.regex = column_dict.get(COLUMN_KEY_VALID_REGEX)
-                    validity.values = YamlHelper.validate_array_value(column_name, COLUMN_KEY_VALID_VALUES,
-                                                                      column_dict.get(COLUMN_KEY_VALID_VALUES))
+                    validity.values = YamlHelper.validate_list_value(column_name, COLUMN_KEY_VALID_VALUES,
+                                                                     column_dict.get(COLUMN_KEY_VALID_VALUES))
                     validity.min = YamlHelper.validate_numeric_value(column_name, COLUMN_KEY_VALID_MIN,
                                                                      column_dict.get(COLUMN_KEY_VALID_MIN))
                     validity.max = YamlHelper.validate_numeric_value(column_name, COLUMN_KEY_VALID_MAX,

--- a/core/sodasql/scan/scan_yml_parser.py
+++ b/core/sodasql/scan/scan_yml_parser.py
@@ -23,6 +23,8 @@ from sodasql.scan.scan_yml_column import ScanYmlColumn
 from sodasql.scan.sql_metric_yml import SqlMetricYml
 from sodasql.scan.test import Test
 from sodasql.scan.validity import Validity
+from sodasql.common.yaml_helper import YamlHelper
+
 
 KEY_TABLE_NAME = 'table_name'
 KEY_METRICS = 'metrics'
@@ -255,7 +257,7 @@ class ScanYmlParser(Parser):
                         self.warning(f'Invalid {column_name}.{COLUMN_KEY_VALID_FORMAT}: {validity.format}')
                     validity.regex = column_dict.get(COLUMN_KEY_VALID_REGEX)
                     validity.values = column_dict.get(COLUMN_KEY_VALID_VALUES)
-                    validity.min = column_dict.get(COLUMN_KEY_VALID_MIN)
+                    validity.min = YamlHelper.validate_numeric_value(column_dict.get(COLUMN_KEY_VALID_MIN))
                     validity.max = column_dict.get(COLUMN_KEY_VALID_MAX)
                     validity.min_length = column_dict.get(COLUMN_KEY_VALID_MIN_LENGTH)
                     validity.max_length = column_dict.get(COLUMN_KEY_VALID_MAX_LENGTH)

--- a/core/sodasql/scan/scan_yml_parser.py
+++ b/core/sodasql/scan/scan_yml_parser.py
@@ -256,8 +256,10 @@ class ScanYmlParser(Parser):
                     if validity.format is not None and Validity.FORMATS.get(validity.format) is None:
                         self.warning(f'Invalid {column_name}.{COLUMN_KEY_VALID_FORMAT}: {validity.format}')
                     validity.regex = column_dict.get(COLUMN_KEY_VALID_REGEX)
+                    #TODO: add check for array as well!
                     validity.values = column_dict.get(COLUMN_KEY_VALID_VALUES)
-                    validity.min = YamlHelper.validate_numeric_value(COLUMN_KEY_VALID_MIN, column_dict.get(COLUMN_KEY_VALID_MIN))
+                    validity.min = YamlHelper.validate_numeric_value(column_name, COLUMN_KEY_VALID_MIN,
+                                                                     column_dict.get(COLUMN_KEY_VALID_MIN))
                     validity.max = column_dict.get(COLUMN_KEY_VALID_MAX)
                     validity.min_length = column_dict.get(COLUMN_KEY_VALID_MIN_LENGTH)
                     validity.max_length = column_dict.get(COLUMN_KEY_VALID_MAX_LENGTH)

--- a/core/sodasql/scan/scan_yml_parser.py
+++ b/core/sodasql/scan/scan_yml_parser.py
@@ -259,7 +259,8 @@ class ScanYmlParser(Parser):
                                                                       column_dict.get(COLUMN_KEY_VALID_VALUES))
                     validity.min = YamlHelper.validate_numeric_value(column_name, COLUMN_KEY_VALID_MIN,
                                                                      column_dict.get(COLUMN_KEY_VALID_MIN))
-                    validity.max = column_dict.get(COLUMN_KEY_VALID_MAX)
+                    validity.max = YamlHelper.validate_numeric_value(column_name, COLUMN_KEY_VALID_MAX,
+                                                                     column_dict.get(COLUMN_KEY_VALID_MAX))
                     validity.min_length = column_dict.get(COLUMN_KEY_VALID_MIN_LENGTH)
                     validity.max_length = column_dict.get(COLUMN_KEY_VALID_MAX_LENGTH)
 

--- a/core/sodasql/scan/scan_yml_parser.py
+++ b/core/sodasql/scan/scan_yml_parser.py
@@ -25,7 +25,6 @@ from sodasql.scan.test import Test
 from sodasql.scan.validity import Validity
 from sodasql.common.yaml_helper import YamlHelper
 
-
 KEY_TABLE_NAME = 'table_name'
 KEY_METRICS = 'metrics'
 KEY_METRIC_GROUPS = 'metric_groups'
@@ -256,8 +255,8 @@ class ScanYmlParser(Parser):
                     if validity.format is not None and Validity.FORMATS.get(validity.format) is None:
                         self.warning(f'Invalid {column_name}.{COLUMN_KEY_VALID_FORMAT}: {validity.format}')
                     validity.regex = column_dict.get(COLUMN_KEY_VALID_REGEX)
-                    validity.values = YamlHelper.validate_numeric_value(column_name, COLUMN_KEY_VALID_VALUES,
-                                                                        column_dict.get(COLUMN_KEY_VALID_VALUES))
+                    validity.values = YamlHelper.validate_array_value(column_name, COLUMN_KEY_VALID_VALUES,
+                                                                      column_dict.get(COLUMN_KEY_VALID_VALUES))
                     validity.min = YamlHelper.validate_numeric_value(column_name, COLUMN_KEY_VALID_MIN,
                                                                      column_dict.get(COLUMN_KEY_VALID_MIN))
                     validity.max = column_dict.get(COLUMN_KEY_VALID_MAX)

--- a/core/sodasql/scan/scan_yml_parser.py
+++ b/core/sodasql/scan/scan_yml_parser.py
@@ -257,7 +257,7 @@ class ScanYmlParser(Parser):
                         self.warning(f'Invalid {column_name}.{COLUMN_KEY_VALID_FORMAT}: {validity.format}')
                     validity.regex = column_dict.get(COLUMN_KEY_VALID_REGEX)
                     validity.values = column_dict.get(COLUMN_KEY_VALID_VALUES)
-                    validity.min = column_dict.get(COLUMN_KEY_VALID_MIN)
+                    validity.min = YamlHelper.validate_numeric_value(COLUMN_KEY_VALID_MIN, column_dict.get(COLUMN_KEY_VALID_MIN))
                     validity.max = column_dict.get(COLUMN_KEY_VALID_MAX)
                     validity.min_length = column_dict.get(COLUMN_KEY_VALID_MIN_LENGTH)
                     validity.max_length = column_dict.get(COLUMN_KEY_VALID_MAX_LENGTH)

--- a/core/sodasql/scan/scan_yml_parser.py
+++ b/core/sodasql/scan/scan_yml_parser.py
@@ -256,8 +256,8 @@ class ScanYmlParser(Parser):
                     if validity.format is not None and Validity.FORMATS.get(validity.format) is None:
                         self.warning(f'Invalid {column_name}.{COLUMN_KEY_VALID_FORMAT}: {validity.format}')
                     validity.regex = column_dict.get(COLUMN_KEY_VALID_REGEX)
-                    #TODO: add check for array as well!
-                    validity.values = column_dict.get(COLUMN_KEY_VALID_VALUES)
+                    validity.values = YamlHelper.validate_numeric_value(column_name, COLUMN_KEY_VALID_VALUES,
+                                                                        column_dict.get(COLUMN_KEY_VALID_VALUES))
                     validity.min = YamlHelper.validate_numeric_value(column_name, COLUMN_KEY_VALID_MIN,
                                                                      column_dict.get(COLUMN_KEY_VALID_MIN))
                     validity.max = column_dict.get(COLUMN_KEY_VALID_MAX)

--- a/tests/common/yaml_helper_test.py
+++ b/tests/common/yaml_helper_test.py
@@ -11,6 +11,15 @@ class YamlHelperTest(unittest.TestCase):
         value = YamlHelper.validate_array_value("column_name", "key", [1, 2, 3])
         self.assertEqual(value, [1, 2, 3])
 
+    def test_invalid_numeric_value(self):
+        value = YamlHelper.validate_numeric_value("column_name", "key", None)
+        self.assertEqual(value, None)
+
+    def test_invalid_array_value(self):
+        value = YamlHelper.validate_array_value("column_name", "key", None)
+        self.assertEqual(value, None)
+
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/common/yaml_helper_test.py
+++ b/tests/common/yaml_helper_test.py
@@ -4,8 +4,12 @@ from sodasql.common.yaml_helper import YamlHelper
 
 class YamlHelperTest(unittest.TestCase):
     def test_valid_numeric_value(self):
-        value = YamlHelper.validate_numeric_value("column_name", 2)
+        value = YamlHelper.validate_numeric_value("column_name", "key", 2)
         self.assertEqual(value, 2)
+
+    def test_valid_array_value(self):
+        value = YamlHelper.validate_array_value("column_name", "key", [1, 2, 3])
+        self.assertEqual(value, [1, 2, 3])
 
 
 if __name__ == '__main__':

--- a/tests/common/yaml_helper_test.py
+++ b/tests/common/yaml_helper_test.py
@@ -1,0 +1,12 @@
+import unittest
+from sodasql.common.yaml_helper import YamlHelper
+
+
+class YamlHelperTest(unittest.TestCase):
+    def test_valid_numeric_value(self):
+        value = YamlHelper.validate_numeric_value("column_name", 2)
+        self.assertEqual(value, 2)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/common/yaml_helper_test.py
+++ b/tests/common/yaml_helper_test.py
@@ -8,7 +8,7 @@ class YamlHelperTest(unittest.TestCase):
         self.assertEqual(value, 2)
 
     def test_valid_array_value(self):
-        value = YamlHelper.validate_array_value("column_name", "key", [1, 2, 3])
+        value = YamlHelper.validate_list_value("column_name", "key", [1, 2, 3])
         self.assertEqual(value, [1, 2, 3])
 
     def test_invalid_numeric_value(self):
@@ -16,7 +16,7 @@ class YamlHelperTest(unittest.TestCase):
         self.assertEqual(value, None)
 
     def test_invalid_array_value(self):
-        value = YamlHelper.validate_array_value("column_name", "key", None)
+        value = YamlHelper.validate_list_value("column_name", "key", None)
         self.assertEqual(value, None)
 
 

--- a/tests/local/warehouse/metrics/test_valid_values.py
+++ b/tests/local/warehouse/metrics/test_valid_values.py
@@ -10,8 +10,7 @@
 #  limitations under the License.
 
 from sodasql.scan.metric import Metric
-from sodasql.scan.scan_yml_parser import KEY_COLUMNS, KEY_METRICS, COLUMN_KEY_VALID_FORMAT, KEY_METRIC_GROUPS, \
-    COLUMN_KEY_VALID_VALUES
+from sodasql.scan.scan_yml_parser import KEY_METRICS
 from tests.common.sql_test_case import SqlTestCase
 
 
@@ -44,6 +43,4 @@ class TestValidValues(SqlTestCase):
           }
         })
         self.assertEqual(scan_result.get(Metric.INVALID_COUNT, 'name'), 3)
-        self.assertEqual(scan_result.get(Metric.VALID_COUNT, 'name'), 2)
-
         self.assertEqual(scan_result.get(Metric.VALID_COUNT, 'size'), 3)

--- a/tests/local/warehouse/metrics/test_valid_values.py
+++ b/tests/local/warehouse/metrics/test_valid_values.py
@@ -42,5 +42,5 @@ class TestValidValues(SqlTestCase):
             }
           }
         })
-        self.assertEqual(scan_result.get(Metric.INVALID_COUNT, 'name'), 3)
+        self.assertEqual(scan_result.get(Metric.INVALID_COUNT, 'name'), 0)
         self.assertEqual(scan_result.get(Metric.VALID_COUNT, 'size'), 3)

--- a/tests/local/warehouse/metrics/test_valid_values.py
+++ b/tests/local/warehouse/metrics/test_valid_values.py
@@ -42,5 +42,5 @@ class TestValidValues(SqlTestCase):
             }
           }
         })
-        self.assertEqual(scan_result.get(Metric.INVALID_COUNT, 'name'), 0)
+        self.assertEqual(scan_result.get(Metric.INVALID_COUNT, 'name'), 3)
         self.assertEqual(scan_result.get(Metric.VALID_COUNT, 'size'), 3)

--- a/tests/local/warehouse/metrics/test_validity.py
+++ b/tests/local/warehouse/metrics/test_validity.py
@@ -129,3 +129,4 @@ class TestValidity(SqlTestCase):
         })
 
         self.assertEqual(scan_result.get(Metric.VALID_COUNT, 'xyz'), 7)
+

--- a/tests/local/warehouse/validity/test_date_and_time_validity_formats.py
+++ b/tests/local/warehouse/validity/test_date_and_time_validity_formats.py
@@ -156,7 +156,7 @@ class TestDateAndTimeValidityFormats(SqlTestCase):
              "('2021, January 21')",
              "('October 21, 2015')",
              "(null)"])
-    
+
         scan_result = self.scan({
             KEY_METRICS: [
                 Metric.INVALID_COUNT,
@@ -170,7 +170,7 @@ class TestDateAndTimeValidityFormats(SqlTestCase):
                 }
             }
         })
-    
+
         self.assertEqual(scan_result.get(Metric.VALUES_COUNT, 'name'), 4)
         self.assertEqual(scan_result.get(Metric.INVALID_COUNT, 'name'), 2)
         self.assertEqual(scan_result.get(Metric.INVALID_PERCENTAGE, 'name'), 40.0)


### PR DESCRIPTION
Being able to validate numerics and arrays:
'valid_min' can only have an int as a value, or else an exception is raised before the scan.
'valid_values' can only be an array, or else an exception is raised before the scan.