### PR TITLE
Add --offline flag to scan cli to skip sending results to Soda Cloud

### DIFF
--- a/core/sodasql/scan/scan_builder.py
+++ b/core/sodasql/scan/scan_builder.py
@@ -69,7 +69,7 @@ class ScanBuilder:
         self.assert_no_warnings_or_errors = True
         self.soda_server_client: SodaServerClient = None
 
-    def build(self):
+    def build(self, offline: bool=False):
         self._build_warehouse_yml()
         self._build_scan_yml()
 
@@ -81,7 +81,8 @@ class ScanBuilder:
         from sodasql.scan.warehouse import Warehouse
         warehouse = Warehouse(self.warehouse_yml)
 
-        self._create_soda_server_client()
+        if not offline:
+            self._create_soda_server_client()
 
         return Scan(warehouse=warehouse,
                     scan_yml=self.scan_yml,


### PR DESCRIPTION
- Added offline flag with default False
- No test added as it would only work on the builder, which would be a pointless test testing that passed parameter is used
- Removed default values for the `scan` cli method as we are using click default values for those params anyway
- Fixes #192 