### PR TITLE
#166 Get bigquery account info from reading an external path

### DIFF
--- a/core/sodasql/scan/dialect.py
+++ b/core/sodasql/scan/dialect.py
@@ -21,6 +21,7 @@ from sodasql.scan.parser import Parser
 
 KEY_WAREHOUSE_TYPE = 'type'
 KEY_CONNECTION_TIMEOUT = 'connection_timeout_sec'
+KEY_ACCOUNT_INFO_JSON_PATH = 'account_info_json_path'
 
 ATHENA = 'athena'
 BIGQUERY = 'bigquery'

--- a/packages/bigquery/sodasql/dialects/bigquery_dialect.py
+++ b/packages/bigquery/sodasql/dialects/bigquery_dialect.py
@@ -128,10 +128,10 @@ class BigQueryDialect(Dialect):
 
     @staticmethod
     def __parse_json_credential(credential_name, parser):
-        account_info_dict_path = parser.get_str_optional('account_info_json_path')
+        account_info_path = parser.get_str_optional('account_info_json_path')
         try:
-            if account_info_dict_path:
-                account_info = parser._read_file_as_string(account_info_dict_path)
+            if account_info_path:
+                account_info = parser._read_file_as_string(account_info_path)
                 if account_info is not None:
                     return json.loads(account_info)
             else:

--- a/packages/bigquery/sodasql/dialects/bigquery_dialect.py
+++ b/packages/bigquery/sodasql/dialects/bigquery_dialect.py
@@ -11,7 +11,6 @@
 import logging
 import json
 from json.decoder import JSONDecodeError
-from typing import Union
 
 from google.api_core.exceptions import Forbidden, NotFound
 from google.auth.exceptions import GoogleAuthError, TransportError
@@ -129,11 +128,17 @@ class BigQueryDialect(Dialect):
 
     @staticmethod
     def __parse_json_credential(credential_name, parser):
+        account_info_dict_path = parser.get_str_optional('account_info_json_path')
         try:
-            cred = parser.get_credential(credential_name)
-            # Prevent json load when the Dialect is init from create command
-            if cred is not None:
-                return json.loads(cred)
+            if account_info_dict_path:
+                account_info = parser._read_file_as_string(account_info_dict_path)
+                if account_info is not None:
+                    return json.loads(account_info)
+            else:
+                cred = parser.get_credential(credential_name)
+                # Prevent json load when the Dialect is init from create command
+                if cred is not None:
+                    return json.loads(cred)
         except JSONDecodeError as e:
             parser.error(f'Error parsing credential {credential_name}: {e}', credential_name)
 


### PR DESCRIPTION
Add support for a new optional field in the yaml file: account_info_json_path, containing an external path to account_info_json creds