### PR TITLE
Fix MySQL dialect issues

### DIFF
--- a/core/sodasql/scan/scan.py
+++ b/core/sodasql/scan/scan.py
@@ -339,7 +339,7 @@ class Scan:
 
             self._flush_measurements(measurements)
         except Exception as e:
-            logger.debug(f'Exception during aggregation query', e)
+            logger.debug(f'Exception during aggregation query', exc_info=e)
             self.scan_result.add_error(ScanError(f'Exception during aggregation query', e))
 
     def _query_group_by_value(self):

--- a/tests/warehouses/mysql_suite.py
+++ b/tests/warehouses/mysql_suite.py
@@ -12,7 +12,7 @@ from tests.common.sql_test_case import TARGET_MYSQL
 from tests.common.sql_test_suite import SqlTestSuite
 
 
-class PostgresSuite(SqlTestSuite):
+class MySqlSuite(SqlTestSuite):
 
     def setUp(self) -> None:
         self.target = TARGET_MYSQL


### PR DESCRIPTION
- change the warehouse type `SQLSERVER` -> `MYSQL`
- fix escape sequences in regex
- fix the weird mysql-connector-python error `UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 1: invalid start byte`
- fix the debug log (don't pass the exc_info object into the log message templated string)
- fix the test suite class name