### PR TITLE
Add equality methods to data classes

### DIFF
--- a/core/sodasql/scan/measurement.py
+++ b/core/sodasql/scan/measurement.py
@@ -8,11 +8,15 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from dataclasses import dataclass
+from dataclasses import dataclass, astuple
 from typing import Optional, List
 
 from sodasql.common.json_helper import JsonHelper
 from sodasql.scan.group_value import GroupValue
+
+
+def is_equal_or_both_none(left, right):
+    return (left == right) or (left is None and right is None)
 
 
 @dataclass
@@ -49,3 +53,12 @@ class Measurement:
             json['columnName'] = self.column_name
 
         return json
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, self.__class__)
+            and all(
+                is_equal_or_both_none(self_field, other_field)
+                for self_field, other_field in zip(astuple(self), astuple(other))
+            )
+        )

--- a/core/sodasql/scan/test.py
+++ b/core/sodasql/scan/test.py
@@ -9,11 +9,16 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, astuple
 from typing import Optional, List
 from jinja2 import Template
 
 logger = logging.getLogger(__name__)
+
+
+def is_equal_or_both_none(left, right):
+    return (left == right) or (left is None and right is None)
+
 
 @dataclass
 class Test:
@@ -56,3 +61,12 @@ class Test:
         except Exception as e:
             logger.error(f'Test error for "{self.expression}": {e}')
             return TestResult(test=self, passed=False, skipped=False, error=e, group_values=group_values)
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, self.__class__)
+            and all(
+                is_equal_or_both_none(self_field, other_field)
+                for self_field, other_field in zip(astuple(self), astuple(other))
+            )
+        )

--- a/core/sodasql/scan/test_result.py
+++ b/core/sodasql/scan/test_result.py
@@ -9,11 +9,15 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, astuple
 from typing import Optional
 
 from sodasql.common.json_helper import JsonHelper
 from sodasql.scan.test import Test
+
+
+def is_equal_or_both_none(left, right):
+    return (left == right) or (left is None and right is None)
 
 
 @dataclass
@@ -63,3 +67,12 @@ class TestResult:
             test_result_json['groupValues'] = JsonHelper.to_jsonnable(self.group_values)
 
         return test_result_json
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, self.__class__)
+            and all(
+                is_equal_or_both_none(self_field, other_field)
+                for self_field, other_field in zip(astuple(self), astuple(other))
+            )
+        )


### PR DESCRIPTION
This equality method helps me to define tests in [`soda-spark`](https://github.com/sodadata/soda-spark/blob/main/tests/test_scan.py) like:

``` python
expected_measurement = Measurement(metric="row_count', column_name=None, value=6)

scan.execute()

assert any(expected_measurement == measurement for measurement in scan.scan_result.measurements
```

Where do I put tests for these methods?