### PR TITLE
Allow spark dialect to have no database specified

### DIFF
--- a/packages/spark/sodasql/dialects/spark_dialect.py
+++ b/packages/spark/sodasql/dialects/spark_dialect.py
@@ -32,7 +32,7 @@ class SparkDialect(Dialect):
             self.port = parser.get_int_optional('port', '10000')
             self.username = parser.get_credential('username')
             self.password = parser.get_credential('password')
-            self.database = parser.get_str_optional('database', 'default')
+            self.database = parser.get_str_optional('database')
             self.auth_method = parser.get_str_optional('authentication', None)
             self.configuration = parser.get_dict_optional('configuration')
 

--- a/packages/spark/sodasql/dialects/spark_dialect.py
+++ b/packages/spark/sodasql/dialects/spark_dialect.py
@@ -58,6 +58,9 @@ class SparkDialect(Dialect):
 
     def sql_tables_metadata(self, limit: str = 10, filter: str = None):
         # TODO Implement limit
+        if self.database is None:
+            raise NotImplementedError("Can not query for tables when database is not given.")
+
         with self.create_connection().cursor() as cursor:
             cursor.execute(f"SHOW TABLES FROM {self.database};")
             return [(row[1],) for row in cursor.fetchall()]

--- a/packages/spark/sodasql/dialects/spark_dialect.py
+++ b/packages/spark/sodasql/dialects/spark_dialect.py
@@ -94,7 +94,8 @@ class SparkDialect(Dialect):
 
     def sql_columns_metadata(self, table_name: str):
         with self.create_connection().cursor() as cursor:
-            cursor.execute(f"DESCRIBE TABLE {self.database}.{table_name}")
+            qualified_table_name = self.qualify_table_name(table_name)
+            cursor.execute(f"DESCRIBE TABLE {qualified_table_name}")
             return [(row[0], row[1], "YES") for row in cursor.fetchall()]
 
     def sql_columns_metadata_query(self, table_name: str) -> str:

--- a/packages/spark/sodasql/dialects/spark_dialect.py
+++ b/packages/spark/sodasql/dialects/spark_dialect.py
@@ -59,7 +59,7 @@ class SparkDialect(Dialect):
     def sql_tables_metadata(self, limit: str = 10, filter: str = None):
         # TODO Implement limit
         if self.database is None:
-            raise NotImplementedError("Can not query for tables when database is not given.")
+            raise NotImplementedError("Cannot query for tables when database is not given.")
 
         with self.create_connection().cursor() as cursor:
             cursor.execute(f"SHOW TABLES FROM {self.database};")

--- a/packages/spark/sodasql/dialects/spark_dialect.py
+++ b/packages/spark/sodasql/dialects/spark_dialect.py
@@ -116,7 +116,11 @@ class SparkDialect(Dialect):
             'FLOAT', 'DOUBLE', 'DOUBLE PRECISION', 'DECIMAL', 'NUMERIC']
 
     def qualify_table_name(self, table_name: str) -> str:
-        return f'{self.database}.{table_name}'
+        if self.database is None:
+            qualified_table_name = table_name
+        else:
+            qualified_table_name = f'{self.database}.{table_name}'
+        return qualified_table_name
 
     def qualify_writable_table_name(self, table_name: str) -> str:
         return self.qualify_table_name(table_name)


### PR DESCRIPTION
In `soda-spark` we register the data frame as global view, we could use a non-global temporary view if we do not need to specify the database. This makes sql metrics (https://github.com/sodadata/soda-spark/pull/78) more intuitive, as you need to defined `global_temp.<table name>` in your `FROM` clause.