### PR TITLE
Make bigquery `account_info_json` optional

### DIFF
--- a/packages/bigquery/sodasql/dialects/bigquery_dialect.py
+++ b/packages/bigquery/sodasql/dialects/bigquery_dialect.py
@@ -164,7 +164,7 @@ class BigQueryDialect(Dialect):
                 if cred is not None:
                     return json.loads(cred)
                 else:
-                    raise Exception("Cannot read credentials from account_info_json")
+                    parser.error("Cannot read credentials from account_info_json")
         except JSONDecodeError as e:
             parser.error(f'Error parsing credential {credential_name}: {e}', credential_name)
 


### PR DESCRIPTION
Log error instead of throw exception

When no account info credentials are found then log error. This is more
consistent with the other behaviour like being unable to decode the json.