### PR TITLE
Dialect - use abstract methods instead of exceptions fixes#565

### DIFF
--- a/core/sodasql/scan/dialect.py
+++ b/core/sodasql/scan/dialect.py
@@ -10,6 +10,7 @@
 #  limitations under the License.
 from __future__ import annotations
 
+import abc
 import re
 from datetime import date
 from numbers import Number
@@ -48,7 +49,7 @@ ALL_WAREHOUSE_TYPES = [ATHENA,
 logger = logging.getLogger(__name__)
 
 
-class Dialect:
+class Dialect(metaclass=abc.ABCMeta):
     data_type_varchar_255 = "VARCHAR(255)"
     data_type_integer = "INTEGER"
     data_type_bigint = "BIGINT"
@@ -130,23 +131,29 @@ class Dialect:
     def sql_connection_test(self):
         return "select 1"
 
+    @abc.abstractmethod
     def create_connection(self):
-        raise RuntimeError('Unimplemented')
+        pass
 
+    @abc.abstractmethod
     def sql_columns_metadata_query(self, table_name: str) -> str:
-        raise RuntimeError('Unimplemented')
+        pass
 
+    @abc.abstractmethod
     def sql_tables_metadata_query(self, limit: Optional[int] = None, filter: str = None):
-        raise RuntimeError('Unimplemented')
+        pass
 
+    @abc.abstractmethod
     def is_text(self, column_type: str):
-        raise RuntimeError('Unimplemented')
+        pass
 
+    @abc.abstractmethod
     def is_number(self, column_type: str):
-        raise RuntimeError('Unimplemented')
+        pass
 
+    @abc.abstractmethod
     def is_time(self, column_type: str):
-        raise RuntimeError('Unimplemented')
+        pass
 
     def create_scan(self, *args, **kwargs):
         # Purpose of this method is to enable dialects to override and

--- a/tests/common/mock_dialect.py
+++ b/tests/common/mock_dialect.py
@@ -1,0 +1,36 @@
+#  Copyright 2020 Soda
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#   http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+from typing import Optional
+from sodasql.scan.dialect import Dialect
+
+
+class MockDialect(Dialect):
+    """Testing dialect without dialect specific methods.
+
+    Used for non specific dialect tests.
+    """
+    def create_connection(self):
+        pass
+
+    def sql_columns_metadata_query(self, table_name: str) -> str:
+        pass
+
+    def sql_tables_metadata_query(self, limit: Optional[int] = None, filter: str = None):
+        pass
+
+    def is_text(self, column_type: str):
+        pass
+
+    def is_number(self, column_type: str):
+        pass
+
+    def is_time(self, column_type: str):
+        pass

--- a/tests/local/independent/test_sql_expressions.py
+++ b/tests/local/independent/test_sql_expressions.py
@@ -10,11 +10,11 @@
 #  limitations under the License.
 from unittest import TestCase
 
-from sodasql.scan.dialect import Dialect
+from tests.common.mock_dialect import MockDialect
 
 
 class TestSqlExpressions(TestCase):
-    dialect = Dialect('test')
+    dialect = MockDialect('test')
 
     def test_string(self):
         self.assertEqual("'hello'", self.dialect.sql_expression({


### PR DESCRIPTION
Fixes #565 