### PR TITLE
Save scan results to a json file

### DIFF
--- a/core/sodasql/cli/cli.py
+++ b/core/sodasql/cli/cli.py
@@ -346,8 +346,12 @@ def analyze(warehouse_file: str, include: str, exclude: str, limit: int):
               is_flag=True,
               default=False,
               help='Use this flag if you want to skip confirmations and run the scan.')
+@click.option('-srf', '--scan-results-file',
+              required=False,
+              default=None,
+              help='Specify the file path where the scan results as json will be stored')
 def scan(scan_yml_file: str, warehouse_yml_file: str, variables: tuple, time: str, offline: bool,
-         non_interactive: bool = False):
+         non_interactive: bool = False, scan_results_file: str = None):
     """
     Computes all measurements and runs all tests on one table.  Exit code 0 means all tests passed.
     Non zero exit code means tests have failed or an exception occurred.
@@ -379,16 +383,14 @@ def scan(scan_yml_file: str, warehouse_yml_file: str, variables: tuple, time: st
         datetime.fromisoformat(time)
         scan_builder.time = time
         scan_builder.non_interactive = non_interactive
+        scan_builder.scan_results_json_path = scan_results_file
 
-        if non_interactive:
-            if not time == datetime.now(tz=timezone.utc).isoformat(timespec='seconds'):
-                logging.warning(f'You are using the --time option with the following value: {time}, meaning that the '
-                                f'actual date of the scan is being altered manually.')
-                answer = input("Are you sure you wish to continue with the --time option? Press 'y' to continue... ")
-                if answer == 'y':
-                    pass
-                else:
-                    sys.exit(1)
+        if non_interactive and not time == datetime.now(tz=timezone.utc).isoformat(timespec='seconds'):
+            logging.warning(f'You are using the --time option with the following value: {time}, meaning that the '
+                            f'actual date of the scan is being altered manually.')
+            answer = input("Are you sure you wish to continue with the --time option? Press 'y' to continue... ")
+            if answer != 'y':
+                sys.exit(1)
 
         logger.info(f'Scanning {scan_yml_file} ...')
 

--- a/core/sodasql/scan/scan.py
+++ b/core/sodasql/scan/scan.py
@@ -11,6 +11,7 @@
 
 import logging
 import os
+import json
 import tempfile
 from datetime import datetime
 from math import floor, ceil
@@ -43,12 +44,14 @@ class Scan:
                  scan_yml: ScanYml = None,
                  soda_server_client: SodaServerClient = None,
                  variables: dict = None,
-                 time: str = None):
+                 time: str = None,
+                 scan_results_file: str = None):
         self.warehouse = warehouse
         self.scan_yml = scan_yml
         self.soda_server_client = soda_server_client
         self.variables = variables
         self.time = time
+        self.scan_results_file = scan_results_file
 
         self.scan_result = ScanResult()
         self.dialect = warehouse.dialect
@@ -116,6 +119,11 @@ class Scan:
 
             if self.close_warehouse:
                 self.warehouse.close()
+
+        if self.scan_results_file is not None:
+            logger.info(f'Saving scan results to {self.scan_results_file}')
+            with open(self.scan_results_file, 'w') as f:
+                json.dump(self.scan_result.to_dict(), f)
 
         return self.scan_result
 

--- a/core/sodasql/scan/scan_builder.py
+++ b/core/sodasql/scan/scan_builder.py
@@ -10,7 +10,7 @@
 #  limitations under the License.
 import logging
 import os
-from typing import List
+from typing import List, Optional
 
 from sodasql.common.yaml_helper import YamlHelper
 from sodasql.scan.file_system import FileSystemSingleton
@@ -22,6 +22,7 @@ from sodasql.scan.warehouse_yml_parser import read_warehouse_yml_file
 from sodasql.soda_server_client.soda_server_client import SodaServerClient
 
 logger = logging.getLogger(__name__)
+
 
 class ScanBuilder:
     """
@@ -57,19 +58,20 @@ class ScanBuilder:
 
     def __init__(self):
         self.file_system = FileSystemSingleton.INSTANCE
-        self.warehouse_yml_file: str = None
-        self.warehouse_yml_dict: dict = None
-        self.warehouse_yml: WarehouseYml = None
-        self.scan_yml_file: str = None
-        self.time: str = None
-        self.scan_yml_dict: dict = None
-        self.scan_yml: ScanYml = None
+        self.warehouse_yml_file: Optional[str] = None
+        self.warehouse_yml_dict: Optional[dict] = None
+        self.warehouse_yml: Optional[WarehouseYml] = None
+        self.scan_yml_file: Optional[str] = None
+        self.time: Optional[str] = None
+        self.scan_yml_dict: Optional[dict] = None
+        self.scan_yml: Optional[ScanYml] = None
         self.variables: dict = {}
         self.parsers: List[Parser] = []
         self.assert_no_warnings_or_errors = True
-        self.soda_server_client: SodaServerClient = None
+        self.soda_server_client: Optional[SodaServerClient] = None
+        self.scan_results_json_path: Optional[str] = None
 
-    def build(self, offline: bool=False):
+    def build(self, offline: bool = False):
         self._build_warehouse_yml()
         self._build_scan_yml()
 
@@ -88,7 +90,8 @@ class ScanBuilder:
                     scan_yml=self.scan_yml,
                     variables=self.variables,
                     soda_server_client=self.soda_server_client,
-                    time=self.time)
+                    time=self.time,
+                    scan_results_file=self.scan_results_json_path)
 
     def _build_warehouse_yml(self):
         if not self.warehouse_yml_file and not self.warehouse_yml_dict and not self.warehouse_yml:
@@ -97,7 +100,8 @@ class ScanBuilder:
 
         elif self.warehouse_yml_file and not self.warehouse_yml_dict and not self.warehouse_yml:
             if not isinstance(self.warehouse_yml_file, str):
-                logger.error(f'scan_builder.warehouse_yml_file must be str, but was {type(self.warehouse_yml_file)}: {self.warehouse_yml_file}')
+                logger.error(
+                    f'scan_builder.warehouse_yml_file must be str, but was {type(self.warehouse_yml_file)}: {self.warehouse_yml_file}')
             else:
                 self.warehouse_yml_dict = read_warehouse_yml_file(self.warehouse_yml_file)
 
@@ -117,7 +121,8 @@ class ScanBuilder:
 
         elif self.scan_yml_file and not self.scan_yml_dict and not self.scan_yml:
             if not isinstance(self.scan_yml_file, str):
-                logger.error(f'scan_builder.scan_yml_file must be str, but was {type(self.scan_yml_file)}: {self.scan_yml_file}')
+                logger.error(
+                    f'scan_builder.scan_yml_file must be str, but was {type(self.scan_yml_file)}: {self.scan_yml_file}')
             elif self.file_system.is_readable_file(self.scan_yml_file):
                 scan_yml_str = self.file_system.file_read_as_str(self.scan_yml_file)
                 if scan_yml_str:


### PR DESCRIPTION
The file can be specified with command line option `-srf` or
`--scan-results-file`.

When using API, the same can be specified via
`scanbuilder.scan_results_json_path`

closes #379