### PR TITLE
Open Telemetry tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
+## [2.1.0b22] - 2021-11-23 *Éowyn*
+- dbt: Add dbt package to releases
+
+## [2.1.0b21] - 2021-11-23 *Éomer*
+ - Core: Use abstract method instead of exceptions (#566) 
+ - Core: Save scan results to a json file (#569)
+ - Core: Introduce Open Telemetry tracing (off by default) (#563)
+ - Core: Support pathlib.Purepath for yaml files (#573)
+ - dbt: Add dbt package to parse manifest and run_results (#572)
+  
 ## [2.1.0b20] - 2021-11-09 *Elrond*
 
 - Core: Fix redshift CI test details

--- a/core/sodasql/cli/cli.py
+++ b/core/sodasql/cli/cli.py
@@ -30,10 +30,11 @@ from sodasql.scan.warehouse_yml_parser import (WarehouseYmlParser,
                                                read_warehouse_yml_file)
 
 from sodasql.telemetry.soda_tracer import soda_trace, span_setup_function_args
-from sodasql.telemetry.soda_telemetry import soda_telemetry
+from sodasql.telemetry.soda_telemetry import SodaTelemetry
 
 LoggingHelper.configure_for_cli()
 logger = logging.getLogger(__name__)
+soda_telemetry = SodaTelemetry.get_instance()
 
 
 @click.group(help=f"Soda CLI version {SODA_SQL_VERSION}")

--- a/core/sodasql/common/config_helper.py
+++ b/core/sodasql/common/config_helper.py
@@ -34,7 +34,7 @@ class ConfigHelper:
     @staticmethod
     def get_instance(path: Optional[str] = None):
         if ConfigHelper.__instance is None:
-            ConfigHelper()
+            ConfigHelper(path)
         return ConfigHelper.__instance
 
     def __init__(self, path: Optional[str] = None):

--- a/core/sodasql/scan/warehouse.py
+++ b/core/sodasql/scan/warehouse.py
@@ -14,9 +14,10 @@ from typing import List
 from sodasql.scan.db import sql_fetchone, sql_fetchall, sql_fetchone_description, sql_fetchall_description
 from sodasql.scan.dialect import Dialect
 from sodasql.scan.warehouse_yml import WarehouseYml
-from sodasql.telemetry.soda_telemetry import soda_telemetry
+from sodasql.telemetry.soda_telemetry import SodaTelemetry
 
 logger = logging.getLogger(__name__)
+soda_telemetry = SodaTelemetry.get_instance()
 
 class Warehouse:
 

--- a/core/sodasql/telemetry/memory_span_exporter.py
+++ b/core/sodasql/telemetry/memory_span_exporter.py
@@ -1,0 +1,46 @@
+import json
+from typing import Dict, List, Sequence
+
+
+from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry.sdk.trace.export import (
+    SpanExporter,
+    SpanExportResult
+)
+
+class MemorySpanExporter(SpanExporter):
+    """Implementation of :class:`SpanExporter` that saves spans in memory.
+
+    This class can be used for diagnostic purposes, multi-threaded scenarios etc.
+    """
+
+    __instance = None
+    __spans = []
+
+    @staticmethod
+    def get_instance():
+        if MemorySpanExporter.__instance is None:
+            MemorySpanExporter()
+        return MemorySpanExporter.__instance
+
+    def __init__(self):
+        if MemorySpanExporter.__instance is not None:
+            raise Exception("This class is a singleton!")
+        else:
+            MemorySpanExporter.__instance = self
+
+    def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
+        for span in spans:
+            self.__spans.append(span)
+        return SpanExportResult.SUCCESS
+
+    def reset(self):
+        self.__spans = []
+
+    @property
+    def spans(self) -> List[ReadableSpan]:
+        return self.__spans
+
+    @property
+    def span_dicts(self) -> List[Dict]:
+        return [json.loads(span.to_json()) for span in self.spans]

--- a/core/sodasql/telemetry/soda_telemetry.py
+++ b/core/sodasql/telemetry/soda_telemetry.py
@@ -1,7 +1,5 @@
 import logging
 import platform
-from typing import Dict
-
 
 from opentelemetry import trace
 from opentelemetry.sdk.resources import Resource
@@ -9,14 +7,15 @@ from opentelemetry.semconv.resource import ResourceAttributes
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import (
     BatchSpanProcessor,
-    ConsoleSpanExporter
+    ConsoleSpanExporter,
+    SimpleSpanProcessor,
 )
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
-from requests.sessions import session
 
 from sodasql.__version__ import SODA_SQL_VERSION
 from sodasql.common.config_helper import ConfigHelper
 from sodasql.scan.dialect import Dialect
+from sodasql.telemetry.memory_span_exporter import MemorySpanExporter
 
 logger = logging.getLogger(__name__)
 soda_config = ConfigHelper.get_instance()
@@ -34,52 +33,84 @@ class SodaTelemetry:
     - `/core/sodasql/cli/cli.py` - CLI arguments and options tracing
     - `/core/sodasql/scan/warehouse.py` - safe datasource type and hash tracing
 
-    This list is not necessarily exhaustive, search for `from sodasql.telemetry.soda_telemetry import soda_telemetry` imports OR
+    This list is not necessarily exhaustive, search for `from sodasql.telemetry.soda_telemetry import SodaTelemetry` imports OR
     `set_attribute` method usage to obtain the full list.
     """
 
     ENDPOINT = 'https://collect.dev.sodadata.io/v1/traces'
+    __instance = None
     __send = True
     soda_config = ConfigHelper.get_instance()
 
-    def __init__(self,  send_anonymous_usage_stats: bool = True):
-        self.__send = send_anonymous_usage_stats
-        if self.__send:
-            logger.info("Sending usage telemetry.")
-            self.__setup()
+    @staticmethod
+    def get_instance(test_mode: bool = False):
+        if test_mode:
+            SodaTelemetry.__instance = None
+
+        if SodaTelemetry.__instance is None:
+            SodaTelemetry(test_mode)
+        return SodaTelemetry.__instance
+
+    def __init__(self, test_mode: bool):
+        if SodaTelemetry.__instance is not None:
+            raise Exception("This class is a singleton!")
         else:
-            logger.info("Skipping usage telemetry.")
+            SodaTelemetry.__instance = self
+
+        self.__send = soda_config.send_anonymous_usage_stats
+
+        if self.__send:
+            logger.info("Setting up usage telemetry.")
+
+            self.__provider = TracerProvider(
+                resource=Resource.create(
+                    {
+                        'os.architecture': platform.architecture(),
+                        'python.version': platform.python_version(),
+                        'python.implementation': platform.python_implementation(),
+                        ResourceAttributes.OS_TYPE: platform.system(),
+                        ResourceAttributes.OS_VERSION: platform.version(),
+                        'platform': platform.platform(),
+                        ResourceAttributes.SERVICE_VERSION: SODA_SQL_VERSION,
+                        ResourceAttributes.SERVICE_NAME: 'soda',
+                        ResourceAttributes.SERVICE_NAMESPACE: 'soda-sql',
+                    }
+                )
+            )
+
+            if test_mode:
+                self.__setup_for_test()
+            else:
+                self.__setup()
+        else:
+            logger.info("Skipping usage telemetry setup.")
 
     def __setup(self):
-        provider = TracerProvider(
-            resource=Resource.create(
-                {
-                    'os.architecture': platform.architecture(),
-                    'python.version': platform.python_version(),
-                    'python.implementation': platform.python_implementation(),
-                    ResourceAttributes.OS_TYPE: platform.system(),
-                    ResourceAttributes.OS_VERSION: platform.version(),
-                    'platform': platform.platform(),
-                    ResourceAttributes.SERVICE_VERSION: SODA_SQL_VERSION,
-                    ResourceAttributes.SERVICE_NAME: 'soda',
-                    ResourceAttributes.SERVICE_NAMESPACE: 'soda-sql',
-                }
-            )
-        )
-        console_span_processor = BatchSpanProcessor(ConsoleSpanExporter())
+        """Set up Open Telemetry processors and exporters for normal use.
+        """
+        logger.debug("Setting ")
         local_debug_mode = self.soda_config.get_value('tracing_local_debug_mode')
 
         if local_debug_mode or logger.getEffectiveLevel() == logging.DEBUG:
-            provider.add_span_processor(console_span_processor)
+            self.__provider.add_span_processor(BatchSpanProcessor(ConsoleSpanExporter()))
 
         if not local_debug_mode:
             otlp_exporter = OTLPSpanExporter(endpoint=self.ENDPOINT)
             otlp_processor = BatchSpanProcessor(otlp_exporter)
-            provider.add_span_processor(otlp_processor)
+            self.__provider.add_span_processor(otlp_processor)
 
-        trace.set_tracer_provider(provider)
+        trace.set_tracer_provider(self.__provider)
+
+    def __setup_for_test(self):
+        """Set up Open Telemetry processors and exporters for usage in tests.
+        """
+        self.__provider.add_span_processor(SimpleSpanProcessor(MemorySpanExporter.get_instance()))
+
+        trace.set_tracer_provider(self.__provider)
 
     def set_attribute(self, key: str, value: str) -> None:
+        """Set attribute value in the current span.
+        """
         if self.__send:
             current_span = trace.get_current_span()
             current_span.set_attribute(key, value)
@@ -91,6 +122,3 @@ class SodaTelemetry:
     @property
     def user_cookie_id(self) -> str:
         return self.soda_config.get_value('user_cookie_id')
-
-# Global
-soda_telemetry = SodaTelemetry(soda_config.send_anonymous_usage_stats)

--- a/tests/common/telemetry_helper.py
+++ b/tests/common/telemetry_helper.py
@@ -1,0 +1,49 @@
+from typing import Dict, List, Tuple, Union
+from functools import wraps
+
+from sodasql.telemetry.soda_telemetry import MemorySpanExporter
+
+telemetry_exporter = MemorySpanExporter.get_instance()
+
+
+def telemetry_ensure_no_secrets(*o_args, **o_kwargs):
+    default_secret_keys = ["secret", "password"]
+    default_secret_values = ["secret", "password", "sodasql"]
+
+    def iteritems_recursive(collection: Union[Dict, List, Tuple]):
+        """Iterates over provided collection and visits every key
+
+        Some magic is present:
+            - tuples and lists are treated as dicts, with numeric indexes added for simplicity
+            - "collection" value is yielded when value is not a simple type - this is so that the key in such case is not missed.
+        """
+        if isinstance(collection, dict):
+            items = collection
+        elif isinstance(collection, tuple) or isinstance(collection, list):
+            items = {i: collection[i] for i in range(0, len(collection))}
+
+        for key, value in items.items():
+            if isinstance(value, dict) or isinstance(value, tuple) or isinstance(value, list):
+                yield key, "collection"
+                yield from iteritems_recursive(value)
+            else:
+                yield key,value
+
+
+    def decorate(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            telemetry_exporter.reset()
+            result = func(*args, **kwargs)
+
+            secret_keys = o_kwargs.get("secret_keys", default_secret_keys)
+            secret_values = o_kwargs.get("secret_values", default_secret_values)
+
+            for span in telemetry_exporter.span_dicts:
+                for key, value in iteritems_recursive(span):
+                    error_msg = f"Forbidden telemetry key:value pair '{key}:{value}'."
+                    assert key not in secret_keys, error_msg
+                    assert value not in secret_values, error_msg
+            return result
+        return wrapper
+    return decorate

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+from sodasql.telemetry.soda_telemetry import SodaTelemetry
+
+# Re-initialize telemetry in test mode.
+soda_telemetry = SodaTelemetry.get_instance(test_mode=True)

--- a/tests/local/independent/test_telemetry.py
+++ b/tests/local/independent/test_telemetry.py
@@ -1,0 +1,116 @@
+import pytest
+
+from typing import Dict, List
+
+from sodasql.telemetry.soda_telemetry import SodaTelemetry
+from sodasql.telemetry.soda_tracer import soda_trace
+from sodasql.telemetry.memory_span_exporter import MemorySpanExporter
+
+from sodasql.__version__ import SODA_SQL_VERSION
+
+from tests.common.telemetry_helper import telemetry_ensure_no_secrets
+
+soda_telemetry = SodaTelemetry.get_instance()
+telemetry_exporter = MemorySpanExporter.get_instance()
+
+
+def dict_has_keys(dict: Dict, keys: List[str]):
+    for key in keys:
+        assert key in dict
+
+
+def test_basic_telemetry_structure():
+    """Test for basic keys and values for any created span."""
+    telemetry_exporter.reset()
+
+    @soda_trace
+    def mock_fn():
+        pass
+
+    mock_fn()
+
+    assert len(telemetry_exporter.span_dicts) == 1
+
+    span = telemetry_exporter.span_dicts[0]
+
+    dict_has_keys(span, ["attributes", "context", "start_time", "end_time", "name", "resource", "status"])
+    dict_has_keys(span["attributes"], ["user_cookie_id"])
+    dict_has_keys(span["context"], ["span_id", "trace_id", "trace_state"])
+    dict_has_keys(span["resource"], ["os.architecture", "os.type", "os.version", "platform", "python.implementation", "python.version", "service.name", "service.namespace", "service.version"])
+
+    resource = span["resource"]
+    assert resource["service.name"] == "soda"
+    assert resource["service.namespace"] == "soda-sql"
+    assert resource["service.version"] == SODA_SQL_VERSION
+
+
+def test_multi_spans():
+    """Test multi spans, the relationship and hierarchy."""
+    telemetry_exporter.reset()
+
+    @soda_trace
+    def mock_fn_1():
+        pass
+
+    @soda_trace
+    def mock_fn_2():
+        pass
+
+    mock_fn_1()
+    mock_fn_2()
+
+    assert len(telemetry_exporter.span_dicts) == 2
+    span_1 = telemetry_exporter.span_dicts[0]
+    span_2 = telemetry_exporter.span_dicts[1]
+
+    assert span_1["attributes"]["user_cookie_id"] == span_2["attributes"]["user_cookie_id"]
+    assert span_1["context"]["trace_id"] == span_2["context"]["trace_id"]
+    assert span_1["context"]["span_id"] == span_2["parent_id"]
+    assert span_1["context"]["span_id"] != span_2["context"]["span_id"]
+
+
+def test_add_argument():
+    """Test that adding a telemetry argument adds it to a span."""
+    telemetry_exporter.reset()
+
+    @soda_trace
+    def mock_fn():
+        soda_telemetry.set_attribute("test", "something")
+        pass
+
+    mock_fn()
+
+    assert len(telemetry_exporter.span_dicts) == 1
+
+    span = telemetry_exporter.span_dicts[0]
+
+    assert "test" in span["attributes"]
+    assert span["attributes"]["test"] == "something"
+
+
+@pytest.mark.parametrize(
+    "key, value",
+    [
+        ("password", "something"),
+        ("something", "secret")
+    ]
+)
+def test_fail_secret(key: str, value: str):
+    """Test that 'no_secrets' test works."""
+    telemetry_exporter.reset()
+
+    with pytest.raises(AssertionError) as e:
+        @telemetry_ensure_no_secrets()
+        def test_fn():
+            @soda_trace
+            def mock_fn():
+                soda_telemetry.set_attribute(key, value)
+                pass
+
+            mock_fn()
+        test_fn()
+
+    error_msg = str(e.value)
+
+    assert "Forbidden telemetry" in error_msg
+    assert key in error_msg or value in error_msg

--- a/tests/local/warehouse/cli/test_cli.py
+++ b/tests/local/warehouse/cli/test_cli.py
@@ -16,6 +16,7 @@ from sodasql.cli.cli import main
 from sodasql.scan.file_system import FileSystem, FileSystemSingleton
 from sodasql.dialects.postgres_dialect import PostgresDialect
 from tests.common.sql_test_case import SqlTestCase
+from tests.common.telemetry_helper import telemetry_ensure_no_secrets
 
 
 class CliWithMockFileSystem(FileSystem):
@@ -82,6 +83,7 @@ class TestCli(SqlTestCase):
     def tearDownClass(cls) -> None:
         FileSystemSingleton.INSTANCE = cls.original_file_system
 
+    @telemetry_ensure_no_secrets()
     def test_cli_tutorial_scenario(self):
         if isinstance(self.warehouse.dialect, PostgresDialect):
             self.load_demo_data()


### PR DESCRIPTION
Adding tests, this required some refactoring
- our telemetry provider is a singleton with test mode
- adding memory span exporter to capture spans across contexts and threads