### PR TITLE
Trigger workflow for main branch or manually

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,9 @@ on:
   push:
     paths-ignore:
       - '**.md'
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   run-tests:


### PR DESCRIPTION
This PR changes changes the Github `build` workflow trigger so that we only run it for the main branch or if you trigger it manually for a specific branch.

We get double the amount of jobs in a PR, for example see #577. It is a bit confusing and a waste of resources. With this change we allow to:

- [x] trigger workflow PR to do checks before merging
- [x] trigger on main to verify it is stable (at least according to the test suite)
- [x] optional, trigger manually for feature branch