### PR TITLE
Docker x86 workaround for running soda-sql on arm based machines

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.7
+
+RUN apt-get update && apt-get -y install gcc libsasl2-dev python-dev unixodbc-dev
+
+RUN mkdir /app
+
+WORKDIR /app
+
+RUN pip install --upgrade pip
+
+COPY . .
+
+RUN pip install "$(cat dev-requirements.in | grep pip-tools)" && \
+    pip install -r dev-requirements.txt && \
+    pip install -r requirements.txt
+
+ENTRYPOINT [ "soda" ]
+CMD [ "scan" ]

--- a/docker-compose-arm.yml
+++ b/docker-compose-arm.yml
@@ -1,0 +1,9 @@
+# docker-compose.yml
+version: "3.8"
+services:
+  soda:
+    build:
+      context: .
+    platform: "linux/amd64"
+    volumes:
+      - .:/app

--- a/scripts/build_for_arm_full.sh
+++ b/scripts/build_for_arm_full.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+docker compose -f docker-compose-arm.yml -p soda-sql build soda

--- a/scripts/run_scan_on_arm.sh
+++ b/scripts/run_scan_on_arm.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+docker compose -f docker-compose-arm.yml -p soda-sql run soda scan "$@"


### PR DESCRIPTION
This is a rough workaround just to get around the ARM issues (Apple Silicon to be more specific) with building dependencies around ssl/cryptography and ODBC. The dockerfile installs all soda dialects and is based on an unnecessarily big base image to keep things simple for now. Hopefully the dependencies issues will be solved soon and this will not be needed.