### PR TITLE
feat: ensure 'soda-sql' is the default source of all Test objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .mysql/
 .vscode/
 mini.vim
+.vim/
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/core/sodasql/scan/test.py
+++ b/core/sodasql/scan/test.py
@@ -24,7 +24,7 @@ class Test:
     metrics: List[str]
     column: Optional[str]
     expression_delimiters = ["<=", ">=", "<", ">", "=="]
-    source: str = field(default="")
+    source: str = field(default="soda-sql")
 
     def evaluate(
         self,

--- a/tests/cli/test_ingest.py
+++ b/tests/cli/test_ingest.py
@@ -79,6 +79,7 @@ def test_dbt_flush_test_results_soda_server_scan_numbertest_result(
         ("skipped", False),
         ("values", {"failures": 0}),
         ("columnName", "result"),
+        ('source', 'dbt'),
     ],
 )
 def test_dbt_flush_test_results_soda_server_scan_test_result(


### PR DESCRIPTION
Makes sure that we explicitly set the source of `Test` objects to be soda-sql unless overridden.
