### PR TITLE
Let ingest have subcommands

### DIFF
--- a/core/sodasql/cli/cli.py
+++ b/core/sodasql/cli/cli.py
@@ -21,7 +21,7 @@ import yaml
 
 from sodasql.__version__ import SODA_SQL_VERSION
 from sodasql.cli.indenting_yaml_dumper import IndentingDumper
-from sodasql.cli.ingest import ingest as _ingest
+from sodasql.cli.ingest import ingest_dbt
 from sodasql.common.logging_helper import LoggingHelper
 from sodasql.dataset_analyzer import DatasetAnalyzer
 from sodasql.scan.file_system import FileSystemSingleton
@@ -493,11 +493,14 @@ def scan(scan_yml_file: str, warehouse_yml_file: str, variables: tuple, time: st
         sys.exit(1)
 
 
-@main.command(short_help="Ingest test information from different tools")
-@click.argument(
-    "tool",
-    required=True,
-    type=click.Choice(["dbt"]),
+@click.group()
+def ingest():
+    """Commands for ingesting test information from other tools."""
+
+
+@ingest.command(
+    name="dbt",
+    short_help="Ingest test information from different tools"
 )
 @click.option(
     "--warehouse-yml-file",
@@ -505,7 +508,7 @@ def scan(scan_yml_file: str, warehouse_yml_file: str, variables: tuple, time: st
     required=True,
 )
 @click.option(
-    "--dbt-artifacts",
+    "--artifacts-directory",
     help=(
         "The path that contains both the manifest and run_result JSONs from dbt. Typically `/dbt_project/target/` "
         "When provided, --dbt-manifest and --dbt-run-results are not required and will be ignored"
@@ -514,25 +517,26 @@ def scan(scan_yml_file: str, warehouse_yml_file: str, variables: tuple, time: st
     type=Path,
 )
 @click.option(
-    "--dbt-manifest",
+    "--manifest-file",
     help="The path to the dbt manifest file",
     default=None,
     type=Path,
 )
 @click.option(
-    "--dbt-run-results",
+    "--run-results-file",
     help="The path to the dbt run results file",
     default=None,
     type=Path,
 )
-def ingest(*args, **kwargs):
+def ingest_dbt(*args, **kwargs):
     """
-    Ingest test information from different tools.
+    Ingest the dbt test information.
 
-    For more details see :func:sodasql.cli.ingest.ingest
+    For more details see :func:sodasql.cli.ingest.ingest_dbt
     """
-    _ingest(*args, **kwargs)
+    ingest_dbt(*args, **kwargs)
 
 
 if __name__ == '__main__':
+    main.add_command(ingest)
     main()

--- a/core/sodasql/cli/cli.py
+++ b/core/sodasql/cli/cli.py
@@ -493,7 +493,7 @@ def scan(scan_yml_file: str, warehouse_yml_file: str, variables: tuple, time: st
         sys.exit(1)
 
 
-@click.group()
+@main.group()
 def ingest():
     """Commands for ingesting test information from other tools."""
 
@@ -538,5 +538,4 @@ def ingest_dbt(*args, **kwargs):
 
 
 if __name__ == '__main__':
-    main.add_command(ingest)
     main()

--- a/core/sodasql/cli/cli.py
+++ b/core/sodasql/cli/cli.py
@@ -494,6 +494,11 @@ def scan(scan_yml_file: str, warehouse_yml_file: str, variables: tuple, time: st
 
 
 @main.group()
+@click.option(
+    "--warehouse-yml-file",
+    help="The warehouse yml file.",
+    required=True,
+)
 def ingest():
     """Commands for ingesting test information from other tools."""
 
@@ -501,11 +506,6 @@ def ingest():
 @ingest.command(
     name="dbt",
     short_help="Ingest test information from different tools"
-)
-@click.option(
-    "--warehouse-yml-file",
-    help="The warehouse yml file.",
-    required=True,
 )
 @click.option(
     "--artifacts-directory",

--- a/core/sodasql/cli/cli.py
+++ b/core/sodasql/cli/cli.py
@@ -21,7 +21,7 @@ import yaml
 
 from sodasql.__version__ import SODA_SQL_VERSION
 from sodasql.cli.indenting_yaml_dumper import IndentingDumper
-from sodasql.cli.ingest import ingest_dbt
+from sodasql.cli import ingest as _ingest
 from sodasql.common.logging_helper import LoggingHelper
 from sodasql.dataset_analyzer import DatasetAnalyzer
 from sodasql.scan.file_system import FileSystemSingleton
@@ -534,7 +534,7 @@ def ingest_dbt(*args, **kwargs):
 
     For more details see :func:sodasql.cli.ingest.ingest_dbt
     """
-    ingest_dbt(*args, **kwargs)
+    _ingest.ingest_dbt(*args, **kwargs)
 
 
 if __name__ == '__main__':

--- a/core/sodasql/cli/ingest.py
+++ b/core/sodasql/cli/ingest.py
@@ -193,28 +193,25 @@ def resolve_artifacts_paths(
     return dbt_manifest, dbt_run_results
 
 
-def ingest(
-    tool: str,
-    warehouse_yml_file: str,
-    dbt_artifacts: Path | None = None,
-    dbt_manifest: Path | None = None,
-    dbt_run_results: Path | None = None,
+def ingest_dbt(
+    warehouse_yml_file: Path,
+    artifacts_directory: Path | None = None,
+    manifest_file: Path | None = None,
+    run_results_file: Path | None = None,
 ) -> None:
     """
-    Ingest test information from different tools.
+    Ingest DBT test information.
 
     Arguments
     ---------
-    tool : str {'dbt'}
-        The tool name.
-    warehouse_yml_file : str
+    warehouse_yml_file : Path
         The warehouse yml file.
-    dbt_artifacts : Optional[Path]
-        The path to the folder conatining both the manifest and run_results.json.
+    artifacts_directory : Optional[Path]
+        The path to the folder containing both the manifest and run_results.json.
         When provided, dbt_manifest and dbt_run_results will be ignored.
-    dbt_manifest : Optional[Path]
+    manifest_file : Optional[Path]
         The path to the dbt manifest.
-    dbt_run_results : Optional[Path]
+    run_results_file : Optional[Path]
         The path to the dbt run results.
 
     Raises
@@ -232,15 +229,12 @@ def ingest(
     if not soda_server_client.api_key_id or not soda_server_client.api_key_secret:
         raise ValueError("Missing Soda cloud api key id and/or secret.")
 
-    if tool == 'dbt':
-        dbt_manifest, dbt_run_results = resolve_artifacts_paths(
-            dbt_artifacts=dbt_artifacts,
-            dbt_manifest=dbt_manifest,
-            dbt_run_results=dbt_run_results
-        )
-        test_results_iterator = map_dbt_test_results_iterator(dbt_manifest, dbt_run_results)
-    else:
-        raise NotImplementedError(f"Unknown tool: {tool}")
+    dbt_manifest, dbt_run_results = resolve_artifacts_paths(
+        artifacts_directory,
+        manifest_file,
+        run_results_file
+    )
+    test_results_iterator = map_dbt_test_results_iterator(dbt_manifest, dbt_run_results)
 
     flush_test_results(
         test_results_iterator,

--- a/tests/cli/test_ingest.py
+++ b/tests/cli/test_ingest.py
@@ -152,15 +152,15 @@ def test_resolve_artifacts_paths(dbt_artifacts, dbt_manifest, dbt_run_results, e
     "dbt_artifacts, dbt_manifest, dbt_run_results",
     [
         pytest.param(
-            "",
-            "",
+            None,
+            None,
             Path('my_dbt_project/target/run_results.json'),
             id="missing dbt_manifest and artifact",
         ),
         pytest.param(
-            "",
+            None,
             Path('my_dbt_project/target/run_results.json'),
-            "",
+            None,
             id="missing dbt_run_results and artifact",
         ),
     ]


### PR DESCRIPTION
This allows us to have flags only shown when a user wants to ingest for that tool:

```
soda ingest dbt --help      # shows flags for dbt
```

```
soda ingest other_tool --help      # shows flags for other_tool
```