### PR TITLE
Add main module

### DIFF
--- a/core/setup.py
+++ b/core/setup.py
@@ -38,7 +38,7 @@ setup(
     long_description_content_type="text/markdown",
     packages=find_namespace_packages(include=["sodasql*"]),
     install_requires=requires,
-    entry_points={"console_scripts": ["soda=sodasql.cli.cli:main"]},
+    entry_points={"console_scripts": ["soda=sodasql.__main__:main"]},
     classifiers=[
         "Development Status :: 4 - Beta",
         "License :: OSI Approved :: Apache Software License",

--- a/core/sodasql/__main__.py
+++ b/core/sodasql/__main__.py
@@ -1,0 +1,5 @@
+from .cli import main
+
+
+if __name__ == "__main__":
+    main()

--- a/core/sodasql/cli/__init__.py
+++ b/core/sodasql/cli/__init__.py
@@ -1,0 +1,1 @@
+from .cli import main


### PR DESCRIPTION
It's the more [pythonic way](https://docs.python.org/3/library/__main__.html) of calling a package. It allows to use Soda like: `python -m sodasql`. 