### PR TITLE
feat: raise error if parsed results contain only null failures

### DIFF
--- a/core/sodasql/cli/ingest.py
+++ b/core/sodasql/cli/ingest.py
@@ -372,7 +372,10 @@ def ingest(
             manifest, run_results = download_dbt_manifest_and_run_result(
                 dbt_cloud_api_token, dbt_cloud_account_id, dbt_cloud_run_id, dbt_cloud_job_id
             )
-
+            with open('manifest.json', 'w') as f:
+                json.dump(manifest, f)
+            with open('run_results.json', 'w') as f:
+                json.dump(run_results, f)
         test_results_iterator = map_dbt_test_results_iterator(manifest, run_results)
     else:
         raise NotImplementedError(f"Unknown tool: {tool}")

--- a/packages/dbt/sodasql/dbt.py
+++ b/packages/dbt/sodasql/dbt.py
@@ -1,11 +1,11 @@
 """dbt integeration"""
-
 from __future__ import annotations
 
+import logging
 from collections import defaultdict
 from functools import reduce
 from operator import or_
-from typing import Any, Iterator
+from typing import Any
 
 from dbt.contracts.graph.compiled import (
     CompiledModelNode,
@@ -21,7 +21,10 @@ from dbt.contracts.graph.parsed import (
 from dbt.contracts.results import RunResultOutput
 from dbt.node_types import NodeType
 
-from sodasql.scan.test_result import TestResult
+from sodasql.common.logging_helper import LoggingHelper
+
+LoggingHelper.configure_for_cli()
+logger = logging.getLogger(__name__)
 
 def parse_manifest(
     manifest: dict[str, Any]
@@ -174,13 +177,15 @@ def all_test_failures_are_not_none(
         if run_result.failures is None:
             results_with_null_failures.append(run_result)
 
-    if len(results_with_null_failures) == run_results:
+    if len(results_with_null_failures) == len(run_results):
         raise ValueError(
             "Could not find a valid test result in the run results. "
             "This is often the case when ingesting from dbt Cloud where the last step in the "
             "job was neither a `dbt build` or `dbt test`. For example, your run may have terminated with "
             "`dbt docs generate` \n"
             "We are currently investigating this with the dbt Cloud team. \n"
+            "In the meantime, if your jobs do not end on the above mentioned commands, you could make sure to add at least a `dbt test` "
+            "step as your last step and make sure that 'generate documentation' is not turned on in your job definition."
         )
     else:
         return True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,3 +105,17 @@ def dbt_run_results(dbt_run_results_file: Path) -> dict:
     with manifest_file.open("r") as file:
         manifest = json.load(file)
     return manifest
+
+
+@pytest.fixture
+def dbt_run_results_null_failures_file(dbt_artifacts_directory: Path) -> Path:
+    run_results_file = dbt_artifacts_directory / "dbt_run_results_null_failures_file.json"
+    return run_results_file
+
+
+@pytest.fixture
+def dbt_run_results_null_failures(dbt_run_results_null_failures_file: Path) -> dict:
+    run_results = Path(__file__).parent / "dbt/data/run_results_null_failures.json"
+    with run_results.open("r") as file:
+        run_results = json.load(file)
+    return run_results

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -107,15 +107,15 @@ def dbt_run_results(dbt_run_results_file: Path) -> dict:
     return manifest
 
 
-@pytest.fixture
-def dbt_run_results_null_failures_file(dbt_artifacts_directory: Path) -> Path:
-    run_results_file = dbt_artifacts_directory / "dbt_run_results_null_failures_file.json"
-    return run_results_file
+# @pytest.fixture
+# def dbt_run_results_null_failures_file(dbt_artifacts_directory: Path) -> Path:
+    # run_results_file = dbt_artifacts_directory / "dbt_run_results_null_failures_file.json"
+    # return run_results_file
 
 
-@pytest.fixture
-def dbt_run_results_null_failures(dbt_run_results_null_failures_file: Path) -> dict:
-    run_results = Path(__file__).parent / "dbt/data/run_results_null_failures.json"
-    with run_results.open("r") as file:
-        run_results = json.load(file)
-    return run_results
+# @pytest.fixture
+# def dbt_run_results_null_failures(dbt_run_results_null_failures_file: Path) -> dict:
+    # run_results = Path(__file__).parent / "dbt/data/run_results_null_failures.json"
+    # with run_results.open("r") as file:
+        # run_results = json.load(file)
+    # return run_results

--- a/tests/dbt/data/run_results_null_failures.json
+++ b/tests/dbt/data/run_results_null_failures.json
@@ -1,0 +1,112 @@
+{
+    "metadata": {
+        "dbt_schema_version": "https://schemas.getdbt.com/dbt/run-results/v4.json"
+    },
+    "results": [
+        {
+            "status": "success",
+            "timing": [
+                {
+                    "name": "compile",
+                    "started_at": "2021-11-19T10:22:58.132733Z",
+                    "completed_at": "2021-11-19T10:22:58.141662Z"
+                },
+                {
+                    "name": "execute",
+                    "started_at": "2021-11-19T10:22:58.142108Z",
+                    "completed_at": "2021-11-19T10:23:02.286903Z"
+                }
+            ],
+            "thread_id": "Thread-1",
+            "execution_time": 3.923800230026245,
+            "adapter_response": {},
+            "message": "OK",
+            "failures": null,
+            "unique_id": "model.soda.stg_soda__scan"
+        },
+        {
+            "status": "pass",
+            "timing": [
+                {
+                    "name": "compile",
+                    "started_at": "2021-11-19T10:22:58.132733Z",
+                    "completed_at": "2021-11-19T10:22:58.141662Z"
+                },
+                {
+                    "name": "execute",
+                    "started_at": "2021-11-19T10:22:58.142108Z",
+                    "completed_at": "2021-11-19T10:23:02.286903Z"
+                }
+            ],
+            "thread_id": "Thread-1",
+            "execution_time": 4.257888078689575,
+            "adapter_response": {},
+            "message": null,
+            "failures": null,
+            "unique_id": "test.soda.accepted_values_stg_soda__scan__result__pass_fail.81f"
+        },
+        {
+            "status": "fail",
+            "timing": [
+                {
+                    "name": "compile",
+                    "started_at": "2021-11-19T10:23:02.506897Z",
+                    "completed_at": "2021-11-19T10:23:02.514333Z"
+                },
+                {
+                    "name": "execute",
+                    "started_at": "2021-11-19T10:23:02.514773Z",
+                    "completed_at": "2021-11-19T10:23:15.568742Z"
+                }
+            ],
+            "thread_id": "Thread-1",
+            "execution_time": 13.31378722190857,
+            "adapter_response": {},
+            "message": null,
+            "failures": null,
+            "unique_id": "test.soda.accepted_values_stg_soda__scan__warehouse__spark__postgres.2e"
+        },
+        {
+            "status": "skipped",
+            "timing": [
+                {
+                    "name": "compile",
+                    "started_at": "2021-11-19T10:22:58.132733Z",
+                    "completed_at": "2021-11-19T10:22:58.141662Z"
+                },
+                {
+                    "name": "execute",
+                    "started_at": "2021-11-19T10:22:58.142108Z",
+                    "completed_at": "2021-11-19T10:23:02.286903Z"
+                }
+            ],
+            "thread_id": "Thread-1",
+            "execution_time": 1.157567024230957,
+            "adapter_response": {},
+            "message": null,
+            "failures": null,
+            "unique_id": "test.soda.accepted_values_soda_warehouses__spark__postgres.c3li140e513"
+        },
+        {
+            "status": "success",
+            "timing": [
+                {
+                    "name": "compile",
+                    "started_at": "2021-11-19T10:22:58.132733Z",
+                    "completed_at": "2021-11-19T10:22:58.141662Z"
+                },
+                {
+                    "name": "execute",
+                    "started_at": "2021-11-19T10:22:58.142108Z",
+                    "completed_at": "2021-11-19T10:23:02.286903Z"
+                }
+            ],
+            "thread_id": "Thread-1",
+            "execution_time": 3.923800230026245,
+            "adapter_response": {},
+            "message": "OK",
+            "failures": null,
+            "unique_id": "test.soda.source_unique_soda_non_existing_source_id.5d2975bf3d"
+        }
+    ]
+}

--- a/tests/dbt/test_dbt.py
+++ b/tests/dbt/test_dbt.py
@@ -98,6 +98,10 @@ def test_parse_run_results_failures(
     assert run_result[0].failures == failures
 
 
+def test_parse_run_results_all_null_failures(dbt_run_results_null_failures):
+    with pytest.raises(ValueError):
+        _ = soda_dbt.parse_run_results(dbt_run_results_null_failures)
+
 @pytest.mark.parametrize(
     "model_name, test_names",
     [


### PR DESCRIPTION
Addresses (but does not close) #649

To close the above issue we might want to hear back from their support engineer who is going to look into what looks like a failure on their API to return the appropriate run_results.json when the job does not end on a test evaluating run.
