### PR TITLE
[cloud] add optional dataset_name to scan YML

### DIFF
--- a/core/sodasql/scan/scan.py
+++ b/core/sodasql/scan/scan.py
@@ -779,7 +779,9 @@ class Scan:
                         }
                     metric['columnName'] = scan_column.column_name
                     metrics.append(metric)
-                results = self.soda_server_client.historic_metrics(self.warehouse, self.scan_yml.table_name, metrics)
+                variables = self.variables.copy() if self.variables else {}
+                dataset_name = Template(self.scan_yml.dataset_name or self.scan_yml.table_name).render(variables)
+                results = self.soda_server_client.historic_metrics(self.warehouse, dataset_name, metrics)
                 measurements = results['measurements']
                 errors = []
                 for name, val in measurements.items():
@@ -904,13 +906,15 @@ class Scan:
     def _ensure_scan_reference(self):
         if self.soda_server_client and not self.scan_reference:
             database_and_schema = self.warehouse.dialect.get_warehouse_name_and_schema()
+            variables = self.variables.copy() if self.variables else {}
+            dataset_name = Template(self.scan_yml.dataset_name or self.scan_yml.table_name).render(variables)
             try:
                 self.start_scan_response = self.soda_server_client.scan_start(
                     self.warehouse.name,
                     self.warehouse.dialect.type,
                     database_and_schema.get("database_name"),
                     database_and_schema.get("database_schema"),
-                    self.scan_yml.table_name,
+                    dataset_name,
                     self.scan_yml.columns,
                     self.time,
                     origin=os.environ.get('SODA_SCAN_ORIGIN', 'external'))

--- a/core/sodasql/scan/scan_yml.py
+++ b/core/sodasql/scan/scan_yml.py
@@ -22,6 +22,7 @@ from sodasql.scan.test import Test
 
 class ScanYml:
     table_name: str = None
+    dataset_name: Optional[str] = None
     metrics: Set[str] = None
     sql_metric_ymls: List[SqlMetricYml] = None
     tests: List[Test] = None

--- a/core/sodasql/scan/scan_yml_parser.py
+++ b/core/sodasql/scan/scan_yml_parser.py
@@ -34,6 +34,7 @@ KEY_SQL_METRICS = 'sql_metrics'
 KEY_TESTS = 'tests'
 KEY_COLUMNS = 'columns'
 KEY_EXCLUDED_COLUMNS = 'excluded_columns'
+KEY_DATASET_NAME = 'dataset_name'
 KEY_MINS_MAXS_LIMIT = 'mins_maxs_limit'
 KEY_FREQUENT_VALUES_LIMIT = 'frequent_values_limit'
 KEY_SAMPLE_PERCENTAGE = 'sample_percentage'
@@ -43,7 +44,8 @@ KEY_SAMPLES = 'samples'
 
 VALID_SCAN_YML_KEYS = [KEY_TABLE_NAME, KEY_METRICS, KEY_METRIC_GROUPS, KEY_SQL_METRICS,
                        KEY_TESTS, KEY_COLUMNS, KEY_MINS_MAXS_LIMIT, KEY_FREQUENT_VALUES_LIMIT,
-                       KEY_SAMPLE_PERCENTAGE, KEY_SAMPLE_METHOD, KEY_FILTER, KEY_SAMPLES, KEY_EXCLUDED_COLUMNS]
+                       KEY_SAMPLE_PERCENTAGE, KEY_SAMPLE_METHOD, KEY_FILTER, KEY_SAMPLES, KEY_EXCLUDED_COLUMNS,
+                       KEY_DATASET_NAME]
 
 COLUMN_KEY_METRICS = KEY_METRICS
 COLUMN_KEY_METRIC_GROUPS = KEY_METRIC_GROUPS
@@ -124,6 +126,7 @@ class ScanYmlParser(Parser):
         self.scan_yml.table_name = table_name
         self.scan_yml.metrics = self.parse_metrics()
         self.scan_yml.excluded_columns = self.get_list_optional(KEY_EXCLUDED_COLUMNS)
+        self.scan_yml.dataset_name = self.get_str_optional(KEY_DATASET_NAME)
 
         self.scan_yml.sql_metric_ymls = self.parse_sql_metric_ymls(KEY_SQL_METRICS)
 
@@ -470,7 +473,7 @@ class ScanYmlParser(Parser):
             finally:
                 self._pop_context()
         pass
-    
+
     def is_dynamic_filter(self, filter: str) -> bool:
         if re.search(r"\{{.*?\}}", filter):
             return True


### PR DESCRIPTION
Scan YML can optionally contain `dataset_name` which will be used to send to the
Soda Cloud.

Given the following Scan YAML:

```yaml
table_name: dim_account
dataset_name: TEST-{{ dataset_counter }}
metrics:
  - row_count
tests:
  - row_count > 0
```

When scan is run with: `soda  scan warehouse.yml dim_account.yml -v
dataset_counter=42` the cloud will see the dataset name as `TEST-42`