### PR TITLE
Fixed PyYaml requirement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ launch a correct PostgreSQL db with the right user and database.
 
 ## Push a release
 
-Make sure that you you install dev-requirements
+Make sure that you install dev-requirements
 ```shell
 pip-compile dev-requirements.in
 pip install -r dev-requirements.txt

--- a/core/setup.py
+++ b/core/setup.py
@@ -22,7 +22,7 @@ requires = [
     "markupsafe==2.0.1",
     "Jinja2>=2.11.3, <4.0",
     "click>=8.0, <9.0",
-    "pyyaml>=5.4.1, <6.0",
+    "pyyaml>=5.4.1",
     "requests>=2.23.0, <3.0",
     "Deprecated>=1.2.13, <1.3",
     "opentelemetry-api~=1.11.0",


### PR DESCRIPTION
There is following conflict which current MR should fix:
```
Because dbt-core (1.3.0) depends on pyyaml (>=6.0)
   and no versions of dbt-core match >1.3.0,<1.4.0, dbt-core (>=1.3.0,<1.4.0) requires pyyaml (>=6.0).
  Thus, soda-sql-bigquery (>=2.2.2,<3.0.0) is incompatible with dbt-core (>=1.3.0,<1.4.0).
```